### PR TITLE
Simplify BlackBox handling, and improve VHDL generation

### DIFF
--- a/clash-lib/src/CLaSH/Driver/TestbenchGen.hs
+++ b/clash-lib/src/CLaSH/Driver/TestbenchGen.hs
@@ -100,9 +100,11 @@ genClock primMap (clkName,Clock rate) = Just clkDecls
       Just (BlackBox _ (Left templ)) -> let (rising,rest) = divMod (toInteger rate) 2
                                             falling       = rising + rest
                                             ctx = emptyBBContext
-                                                    { bbResult    = (Left (Identifier clkName Nothing), Clock rate)
-                                                    , bbInputs    = [error $ "clockGen input " ++ show i ++ " must be accessed with ~LIT[" ++ show (i :: Integer) ++ "]\n" ++ show templ | i <- [0..] ]
-                                                    , bbLitInputs = [N.Literal Nothing (NumLit 2), N.Literal Nothing (NumLit rising), N.Literal Nothing (NumLit falling)] ++ [ (error $ "resetGen has no ~LIT[" ++ show (i :: Integer) ++ "]\n" ++ show templ) | i <- [2..] ]
+                                                    { bbResult = (Left (Identifier clkName Nothing), Clock rate)
+                                                    , bbInputs = [ (Left (N.Literal Nothing (NumLit 2)),Integer,True)
+                                                                 , (Left (N.Literal Nothing (NumLit rising)),Integer,True)
+                                                                 , (Left (N.Literal Nothing (NumLit falling)),Integer,True)
+                                                                 ]
                                                     }
                                         in  BlackBoxD "CLaSH.Driver.TestbenchGen.clockGen" (parseFail templ) ctx
       pM -> error $ $(curLoc) ++ ("Can't make clock declaration for: " ++ show pM)
@@ -120,9 +122,8 @@ genReset primMap (rstName,Reset clk) = Just rstDecls
   where
     resetGenDecl = case HashMap.lookup "CLaSH.Driver.TestbenchGen.resetGen" primMap of
       Just (BlackBox _ (Left templ)) -> let ctx = emptyBBContext
-                                                    { bbResult    = (Left (Identifier rstName Nothing), Reset clk)
-                                                    , bbInputs    = [error $ "resetGen input " ++ show i ++ " must be accessed with ~LIT[" ++ show (i :: Integer) ++ "]\n" ++ show templ | i <- [0..] ]
-                                                    , bbLitInputs = (N.Literal Nothing (NumLit 1)) : [ (error $ "resetGen has no ~LIT[" ++ show (i :: Integer) ++ "]\n" ++ show templ) | i <- [1..] ]
+                                                    { bbResult = (Left (Identifier rstName Nothing), Reset clk)
+                                                    , bbInputs = [(Left (N.Literal Nothing (NumLit 1)),Integer,True)]
                                                     }
                                         in  BlackBoxD "CLaSH.Driver.TestbenchGen.resetGen" (parseFail templ) ctx
       pM -> error $ $(curLoc) ++ ("Can't make reset declaration for: " ++ show pM)
@@ -137,9 +138,10 @@ genFinish :: PrimMap
           -> Declaration
 genFinish primMap = case HashMap.lookup "CLaSH.Driver.TestbenchGen.finishedGen" primMap of
   Just (BlackBox _ (Left templ)) -> let ctx = emptyBBContext
-                                                { bbResult    = (Left (Identifier "finished" Nothing), Bool)
-                                                , bbInputs    = [ (error $ "finishedGen input " ++ show i ++ " must be accessed with ~LIT[" ++ show (i :: Integer) ++ "]\n" ++ show templ) | i <- [0..] ]
-                                                , bbLitInputs = (N.Literal Nothing (BoolLit True)) : (N.Literal Nothing (NumLit 100)) : [ (error $ "resetGen has no ~LIT[" ++ show (i :: Integer) ++ "]\n" ++ show templ) | i <- [1..] ]
+                                                { bbResult = (Left (Identifier "finished" Nothing), Bool)
+                                                , bbInputs = [ (Left (N.Literal Nothing (BoolLit True)),Bool,True)
+                                                             , (Left (N.Literal Nothing (NumLit 100)),Integer,True)
+                                                             ]
                                                 }
                                     in  BlackBoxD "CLaSH.Driver.TestbenchGen.finishGen" (parseFail templ) ctx
   pM -> error $ $(curLoc) ++ ("Can't make finish declaration for: " ++ show pM)
@@ -149,8 +151,7 @@ genDone :: PrimMap
 genDone primMap = case HashMap.lookup "CLaSH.Driver.TestbenchGen.doneGen" primMap of
   Just (BlackBox _ (Left templ)) -> let ctx = emptyBBContext
                                                 { bbResult    = (Left (Identifier "done" Nothing), Bool)
-                                                , bbInputs    = (Left (Identifier "finished" Nothing),Bool) : [ (error $ "doneGen input " ++ show i ++ " must be accessed with ~LIT[" ++ show (i :: Integer) ++ "]\n" ++ show templ) | i <- [0..] ]
-                                                , bbLitInputs = [ (error $ "doneGen has no ~LIT[" ++ show (i :: Integer) ++ "]\n" ++ show templ) | i <- [0..] ]
+                                                , bbInputs    = [(Left (Identifier "finished" Nothing),Bool,False)]
                                                 }
                                     in  BlackBoxD "CLaSH.Driver.TestbenchGen.doneGen" (parseFail templ) ctx
   pM -> error $ $(curLoc) ++ ("Can't make done declaration for: " ++ show pM)

--- a/clash-lib/src/CLaSH/Driver/TestbenchGen.hs
+++ b/clash-lib/src/CLaSH/Driver/TestbenchGen.hs
@@ -48,15 +48,15 @@ genTestBench :: DebugLevel
              -> IO ([Component])
 genTestBench dbgLvl supply primMap typeTrans tcm eval cmpCnt globals stimuliNmM expectedNmM
   (Component cName hidden [inp] outp _) = do
-  let ioDecl  = [ uncurry NetDecl inp  Nothing
-                , uncurry NetDecl outp Nothing
+  let ioDecl  = [ uncurry NetDecl inp
+                , uncurry NetDecl outp
                 ]
       inpExpr = Assignment (fst inp) (BlackBoxE "" [Err Nothing] (emptyBBContext {bbResult = (undefined,snd inp)}) False)
   (inpInst,inpComps,cmpCnt',hidden') <- maybe (return (inpExpr,[],cmpCnt,hidden))
                                                  (genStimuli cmpCnt primMap globals typeTrans tcm normalizeSignal hidden inp)
                                                  stimuliNmM
 
-  let finDecl = [ NetDecl "finished" Bool (Just (N.Literal Nothing (BoolLit False)))
+  let finDecl = [ NetDecl "finished" Bool
                 , genDone primMap
                 ]
       finExpr = genFinish primMap
@@ -109,7 +109,7 @@ genClock primMap (clkName,Clock rate) = Just clkDecls
                                         in  BlackBoxD "CLaSH.Driver.TestbenchGen.clockGen" (parseFail templ) ctx
       pM -> error $ $(curLoc) ++ ("Can't make clock declaration for: " ++ show pM)
 
-    clkDecls   = [ NetDecl clkName (Clock rate) (Just (N.Literal Nothing (BitLit L)))
+    clkDecls   = [ NetDecl clkName (Clock rate)
                  , clkGenDecl
                  ]
 
@@ -128,7 +128,7 @@ genReset primMap (rstName,Reset clk) = Just rstDecls
                                         in  BlackBoxD "CLaSH.Driver.TestbenchGen.resetGen" (parseFail templ) ctx
       pM -> error $ $(curLoc) ++ ("Can't make reset declaration for: " ++ show pM)
 
-    rstDecls = [ NetDecl rstName (Reset clk) Nothing
+    rstDecls = [ NetDecl rstName (Reset clk)
                , resetGenDecl
                ]
 
@@ -139,9 +139,7 @@ genFinish :: PrimMap
 genFinish primMap = case HashMap.lookup "CLaSH.Driver.TestbenchGen.finishedGen" primMap of
   Just (BlackBox _ (Left templ)) -> let ctx = emptyBBContext
                                                 { bbResult = (Left (Identifier "finished" Nothing), Bool)
-                                                , bbInputs = [ (Left (N.Literal Nothing (BoolLit True)),Bool,True)
-                                                             , (Left (N.Literal Nothing (NumLit 100)),Integer,True)
-                                                             ]
+                                                , bbInputs = [ (Left (N.Literal Nothing (NumLit 100)),Integer,True) ]
                                                 }
                                     in  BlackBoxD "CLaSH.Driver.TestbenchGen.finishGen" (parseFail templ) ctx
   pM -> error $ $(curLoc) ++ ("Can't make finish declaration for: " ++ show pM)

--- a/clash-lib/src/CLaSH/Netlist.hs
+++ b/clash-lib/src/CLaSH/Netlist.hs
@@ -133,7 +133,6 @@ genComponentT compName componentExpr mStart = do
   let netDecls = map (\(id_,_) ->
                         NetDecl (mkBasicId . Text.pack . name2String $ varName id_)
                                 (unsafeCoreTypeToHWType $(curLoc) typeTrans tcm . unembed $ varType id_)
-                                Nothing
                      ) $ filter ((/= result) . varName . fst) binders
   (decls,clks) <- listen $ concat <$> mapM (uncurry mkDeclarations . second unembed) binders
 
@@ -168,7 +167,7 @@ mkDeclarations bndr e@(Case scrut _ [alt]) = do
                         i   <- varCount <<%= (+1)
                         let tmpNm   = "tmp_" ++ show i
                             tmpNmT  = Text.pack tmpNm
-                            tmpDecl = NetDecl tmpNmT sHwTy Nothing
+                            tmpDecl = NetDecl tmpNmT sHwTy
                             tmpAssn = Assignment tmpNmT newExpr
                         return (tmpNmT,newDecls ++ [tmpDecl,tmpAssn])
   let dstId    = mkBasicId . Text.pack . name2String $ varName bndr

--- a/clash-lib/src/CLaSH/Netlist.hs
+++ b/clash-lib/src/CLaSH/Netlist.hs
@@ -274,7 +274,7 @@ mkExpr bbEasD ty app = do
     Data dc
       | all (\e -> isConstant e || isVar e) tmArgs -> mkDcApplication hwTy dc tmArgs
       | otherwise                                  -> error $ $(curLoc) ++ "Not in normal form: DataCon-application with non-Simple arguments"
-    Prim nm _ -> first fst <$> mkPrimitive False bbEasD nm args ty
+    Prim nm _ -> mkPrimitive False bbEasD nm args ty
     Var _ f
       | null tmArgs -> return (Identifier (mkBasicId . Text.pack $ name2String f) Nothing,[])
       | otherwise -> error $ $(curLoc) ++ "Not in normal form: top-level binder in argument position: " ++ showDoc app

--- a/clash-lib/src/CLaSH/Netlist/BlackBox.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox.hs
@@ -136,7 +136,7 @@ mkPrimitive bbEParen bbEasD nm args ty = do
       let hwTy    = snd $ bbResult bbCtx
       case template p of
         (Left tempD) -> do
-          let tmpDecl = NetDecl tmpNmT hwTy Nothing
+          let tmpDecl = NetDecl tmpNmT hwTy
               pNm     = name p
           bbDecl <- N.BlackBoxD pNm <$> prepareBlackBox pNm tempD bbCtx <*> pure bbCtx
           return (Identifier tmpNmT Nothing,ctxDcls ++ [tmpDecl,bbDecl])
@@ -144,7 +144,7 @@ mkPrimitive bbEParen bbEasD nm args ty = do
           let pNm = name p
           bbTempl <- prepareBlackBox pNm tempE bbCtx
           if bbEasD
-            then let tmpDecl  = NetDecl tmpNmT hwTy Nothing
+            then let tmpDecl  = NetDecl tmpNmT hwTy
                      tmpAssgn = Assignment tmpNmT (BlackBoxE pNm bbTempl bbCtx bbEParen)
                  in  return (Identifier tmpNmT Nothing, ctxDcls ++ [tmpDecl,tmpAssgn])
             else return (BlackBoxE pNm bbTempl bbCtx bbEParen,ctxDcls)
@@ -166,8 +166,8 @@ mkPrimitive bbEParen bbEasD nm args ty = do
               (scrutExpr,scrutDecls) <- mkExpr False scrutTy scrut
               let tmpRhs       = pack ("tmp_tte_rhs_" ++ show i)
                   tmpS         = pack ("tmp_tte_" ++ show i)
-                  netDeclRhs   = NetDecl tmpRhs scrutHTy Nothing
-                  netDeclS     = NetDecl tmpS hwTy Nothing
+                  netDeclRhs   = NetDecl tmpRhs scrutHTy
+                  netDeclS     = NetDecl tmpS hwTy
                   netAssignRhs = Assignment tmpRhs scrutExpr
                   netAssignS   = Assignment tmpS (DataTag hwTy (Left tmpRhs))
               return (Identifier tmpS Nothing,[netDeclRhs,netDeclS,netAssignRhs,netAssignS] ++ scrutDecls)
@@ -183,8 +183,8 @@ mkPrimitive bbEParen bbEasD nm args ty = do
             (scrutExpr,scrutDecls) <- mkExpr False scrutTy scrut
             let tmpRhs       = pack ("tmp_dtt_rhs_" ++ show i)
                 tmpS         = pack ("tmp_dtt_" ++ show j)
-                netDeclRhs   = NetDecl tmpRhs scrutHTy Nothing
-                netDeclS     = NetDecl tmpS Integer  Nothing
+                netDeclRhs   = NetDecl tmpRhs scrutHTy
+                netDeclS     = NetDecl tmpS Integer
                 netAssignRhs = Assignment tmpRhs scrutExpr
                 netAssignS   = Assignment tmpS   (DataTag scrutHTy (Right tmpRhs))
             return (Identifier tmpS Nothing,[netDeclRhs,netDeclS,netAssignRhs,netAssignS] ++ scrutDecls)

--- a/clash-lib/src/CLaSH/Netlist/BlackBox.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox.hs
@@ -9,13 +9,9 @@ module CLaSH.Netlist.BlackBox where
 
 import           Control.Lens                  ((.=),(<<%=))
 import qualified Control.Lens                  as Lens
-import           Control.Monad                 (filterM, mzero)
-import           Control.Monad.Trans.Class     (lift)
-import           Control.Monad.Trans.Maybe     (MaybeT (..))
-import           Data.Either                   (lefts, partitionEithers)
+import           Control.Monad                 (filterM)
+import           Data.Either                   (lefts)
 import qualified Data.HashMap.Lazy             as HashMap
-import           Data.List                     (partition)
-import           Data.Maybe                    (catMaybes)
 import           Data.Monoid                   (mconcat)
 import           Data.Text.Lazy                (Text, fromStrict, pack)
 import qualified Data.Text.Lazy                as Text
@@ -28,7 +24,7 @@ import           Unbound.LocallyNameless       (embed, name2String, string2Name,
 import           CLaSH.Core.DataCon            as D (dcTag)
 import           CLaSH.Core.Literal            as L (Literal (..))
 import           CLaSH.Core.Pretty             (showDoc)
-import           CLaSH.Core.Term               as C (Term (..), TmName)
+import           CLaSH.Core.Term               as C (Term (..))
 import           CLaSH.Core.Type               as C (Type (..), ConstTy (..),
                                                 splitFunTys)
 import           CLaSH.Core.TyCon              as C (tyConDataCons)
@@ -53,26 +49,22 @@ mkBlackBoxContext :: Id -- ^ Identifier binding the primitive/blackbox applicati
 mkBlackBoxContext resId args = do
     -- Make context inputs
     tcm                   <- Lens.use tcCache
-    args'                 <- fmap (zip args) $ mapM (isFun tcm) args
-    (varInps,declssV)     <- fmap (unzip . catMaybes)  $ mapM (runMaybeT . mkInput) args'
-    let (_,otherArgs)     = partitionEithers $ map unVar args'
-        (litArgs,funArgs) = partition (\(t,b) -> not b && isConstant t) otherArgs
-    (litInps,declssL)     <- fmap (unzip . catMaybes) $ mapM (runMaybeT . mkLitInput . fst) litArgs
-    (funInps,declssF)     <- fmap (unzip . catMaybes) $ mapM (runMaybeT . mkFunInput resId . fst) funArgs
+    (imps,impDecls)       <- unzip <$> mapM mkArgument args
+    (funs,funDecls)       <- unzip <$> mapM (\a -> do isF <- isFun tcm a
+                                                      if isF
+                                                         then first Just <$> mkFunInput resId a
+                                                         else return (Nothing,[])
+                                            ) args
 
     -- Make context result
     let res = case synchronizedClk tcm (unembed $ V.varType resId) of
                 Just clk -> Right . (,clk) . (`N.Identifier` Nothing) . mkBasicId . pack $ name2String (V.varName resId)
                 Nothing  -> Left . (`N.Identifier` Nothing) . mkBasicId . pack $ name2String (V.varName resId)
-    resTy <- N.unsafeCoreTypeToHWTypeM $(curLoc) (unembed $ V.varType resId)
+    resTy <- unsafeCoreTypeToHWTypeM $(curLoc) (unembed $ V.varType resId)
 
-    return ( Context (res,resTy) varInps (map fst litInps) funInps
-           , concat declssV ++ concat declssL ++ concat declssF
+    return ( Context (res,resTy) imps funs
+           , concat impDecls ++ concat funDecls
            )
-  where
-    unVar :: (Term, Bool) -> Either TmName (Term, Bool)
-    unVar (Var _ v, False) = Left v
-    unVar t                = Right t
 
 prepareBlackBox :: TextS.Text
                 -> Text
@@ -80,7 +72,7 @@ prepareBlackBox :: TextS.Text
                 -> NetlistMonad BlackBoxTemplate
 prepareBlackBox pNm t bbCtx =
   let (templ,err) = runParse t
-  in  if null err && verifyBlackBoxContext templ bbCtx
+  in  if null err && verifyBlackBoxContext bbCtx templ
          then do
            templ'  <- instantiateSym templ
            templ'' <- setClocks bbCtx templ'
@@ -90,34 +82,43 @@ prepareBlackBox pNm t bbCtx =
                    "\nwith context:\n" ++ show bbCtx ++ "\ngiven errors:\n" ++
                    show err
 
-
--- | Create an template instantiation text for an argument term
-mkInput :: (Term, Bool)
-        -> MaybeT NetlistMonad ((SyncExpr,HWType),[Declaration])
-mkInput (_, True) = return ((Left $ Identifier (pack "__FUN__") Nothing, Void),[])
-
-mkInput (Var ty v, False) = do
-  let vT = Identifier (mkBasicId . pack $ name2String v) Nothing
-  tcm <- Lens.use tcCache
-  hwTy <- lift $ N.unsafeCoreTypeToHWTypeM $(curLoc) ty
-  return $ case synchronizedClk tcm ty of
-    Just clk -> ((Right (vT,clk), hwTy), [])
-    Nothing  -> ((Left  vT,       hwTy), [])
-
-mkInput (e, False) = case collectArgs e of
-  (Prim f _, args) -> do
-    tcm <- Lens.use tcCache
-    ty  <- termType tcm e
-    ((exprN,hwTy),decls) <- lift $ mkPrimitive True False f args ty
-    return ((Left exprN,hwTy),decls)
-  _ -> fmap (first (first Left)) $ mkLitInput e
+mkArgument :: Term
+           -> NetlistMonad ( (SyncExpr,HWType,Bool)
+                           , [Declaration]
+                           )
+mkArgument e = do
+    tcm   <- Lens.use tcCache
+    ty    <- termType tcm e
+    hwTyM <- N.termHWTypeM e
+    ((e',t,l),d) <- case hwTyM of
+      Nothing   -> return ((Identifier "__VOID__" Nothing,Void,False),[])
+      Just hwTy -> case collectArgs e of
+        (Var _ v,[]) -> let vT = Identifier (mkBasicId . pack $ name2String v) Nothing
+                        in  return ((vT,hwTy,False),[])
+        (C.Literal (IntegerLiteral i),[]) -> return ((N.Literal Nothing (N.NumLit i),hwTy,True),[])
+        (Prim f _,args) -> do
+          (e',d) <- mkPrimitive True False f args ty
+          case e' of
+            (Identifier _ _) -> return ((e',hwTy,False), d)
+            _                -> return ((e',hwTy,isConstant e), d)
+        (Data dc, args) -> do
+            typeTrans <- Lens.use typeTranslator
+            args' <- filterM (fmap (representableType typeTrans tcm) . termType tcm) (lefts args)
+            (exprN,dcDecls) <- mkDcApplication hwTy dc args'
+            return ((exprN,hwTy,isConstant e),dcDecls)
+        _ -> return ((Identifier "__VOID__" Nothing,hwTy,False),[])
+    return ((addClock tcm ty e',t,l),d)
+  where
+    addClock tcm ty e' = case synchronizedClk tcm ty of
+                           Just clk -> Right (e',clk)
+                           _        -> Left  e'
 
 mkPrimitive :: Bool -- ^ Put BlackBox expression in parenthesis
             -> Bool -- ^ Treat BlackBox expression as declaration
             -> TextS.Text
             -> [Either Term Type]
             -> Type
-            -> NetlistMonad ((Expr,HWType),[Declaration])
+            -> NetlistMonad (Expr,[Declaration])
 mkPrimitive bbEParen bbEasD nm args ty = do
   bbM <- HashMap.lookup nm <$> Lens.use primitives
   case bbM of
@@ -133,15 +134,15 @@ mkPrimitive bbEParen bbEasD nm args ty = do
           let tmpDecl = NetDecl tmpNmT hwTy Nothing
               pNm     = name p
           bbDecl <- N.BlackBoxD pNm <$> prepareBlackBox pNm tempD bbCtx <*> pure bbCtx
-          return ((Identifier tmpNmT Nothing,hwTy),ctxDcls ++ [tmpDecl,bbDecl])
+          return (Identifier tmpNmT Nothing,ctxDcls ++ [tmpDecl,bbDecl])
         (Right tempE) -> do
           let pNm = name p
           bbTempl <- prepareBlackBox pNm tempE bbCtx
           if bbEasD
             then let tmpDecl  = NetDecl tmpNmT hwTy Nothing
                      tmpAssgn = Assignment tmpNmT (BlackBoxE pNm bbTempl bbCtx bbEParen)
-                 in  return ((Identifier tmpNmT Nothing, hwTy), ctxDcls ++ [tmpDecl,tmpAssgn])
-            else return ((BlackBoxE pNm bbTempl bbCtx bbEParen,hwTy),ctxDcls)
+                 in  return (Identifier tmpNmT Nothing, ctxDcls ++ [tmpDecl,tmpAssgn])
+            else return (BlackBoxE pNm bbTempl bbCtx bbEParen,ctxDcls)
     Just (P.Primitive pNm _)
       | pNm == "GHC.Prim.tagToEnum#" -> do
           hwTy <- N.unsafeCoreTypeToHWTypeM $(curLoc) ty
@@ -151,7 +152,7 @@ mkPrimitive bbEParen bbEasD nm args ty = do
               let dcs = tyConDataCons (tcm HashMap.! tcN)
                   dc  = dcs !! fromInteger i
               (exprN,dcDecls) <- mkDcApplication hwTy dc []
-              return ((exprN,hwTy),dcDecls)
+              return (exprN,dcDecls)
             [Right _, Left scrut] -> do
               i <- varCount <<%= (+1)
               tcm     <- Lens.use tcCache
@@ -164,10 +165,10 @@ mkPrimitive bbEParen bbEasD nm args ty = do
                   netDeclS     = NetDecl tmpS hwTy Nothing
                   netAssignRhs = Assignment tmpRhs scrutExpr
                   netAssignS   = Assignment tmpS (DataTag hwTy (Left tmpRhs))
-              return ((Identifier tmpS Nothing,hwTy),[netDeclRhs,netDeclS,netAssignRhs,netAssignS] ++scrutDecls)
+              return (Identifier tmpS Nothing,[netDeclRhs,netDeclS,netAssignRhs,netAssignS] ++ scrutDecls)
             _ -> error $ $(curLoc) ++ "tagToEnum: " ++ show (map (either showDoc showDoc) args)
       | pNm == "GHC.Prim.dataToTag#" -> case args of
-          [Right _,Left (Data dc)] -> return ((N.Literal Nothing (NumLit $ toInteger $ dcTag dc - 1),Integer),[])
+          [Right _,Left (Data dc)] -> return (N.Literal Nothing (NumLit $ toInteger $ dcTag dc - 1),[])
           [Right _,Left scrut] -> do
             i <- varCount <<%= (+1)
             j <- varCount <<%= (+1)
@@ -181,42 +182,20 @@ mkPrimitive bbEParen bbEasD nm args ty = do
                 netDeclS     = NetDecl tmpS Integer  Nothing
                 netAssignRhs = Assignment tmpRhs scrutExpr
                 netAssignS   = Assignment tmpS   (DataTag scrutHTy (Right tmpRhs))
-            return ((Identifier tmpS Nothing,Integer),[netDeclRhs,netDeclS,netAssignRhs,netAssignS] ++ scrutDecls)
+            return (Identifier tmpS Nothing,[netDeclRhs,netDeclS,netAssignRhs,netAssignS] ++ scrutDecls)
           _ -> error $ $(curLoc) ++ "dataToTag: " ++ show (map (either showDoc showDoc) args)
-      | otherwise -> return ((BlackBoxE "" [C $ mconcat ["NO_TRANSLATION_FOR:",fromStrict pNm]] emptyBBContext False,Void),[])
+      | otherwise -> return (BlackBoxE "" [C $ mconcat ["NO_TRANSLATION_FOR:",fromStrict pNm]] emptyBBContext False,[])
     _ -> error $ $(curLoc) ++ "No blackbox found for: " ++ unpack nm
-
--- | Create an template instantiation text for an argument term, given that
--- the term is a literal. Returns 'Nothing' if the term is not a literal.
-mkLitInput :: Term -- ^ The literal argument term
-           -> MaybeT NetlistMonad ((Expr,HWType),[Declaration])
-mkLitInput (C.Literal (IntegerLiteral i))     = return ((N.Literal Nothing (N.NumLit i),Integer),[])
-mkLitInput e@(collectArgs -> (Data dc, args)) = lift $ do
-  typeTrans <- Lens.use typeTranslator
-  tcm   <- Lens.use tcCache
-  args' <- filterM (fmap (representableType typeTrans tcm) . termType tcm) (lefts args)
-  hwTy  <- N.termHWType $(curLoc) e
-  (exprN,dcDecls) <- mkDcApplication hwTy dc args'
-  return ((exprN,hwTy),dcDecls)
-mkLitInput e@(collectArgs -> (Prim pNm _, args)) = do
-  tcm <- lift $ Lens.use tcCache
-  ty  <- lift $ termType tcm e
-  r@((e',_),_) <- lift $ mkPrimitive False False pNm args ty
-  case e' of
-    (Identifier _ _) -> mzero
-    _                -> return r
-
-mkLitInput _ = mzero
 
 -- | Create an template instantiation text and a partial blackbox content for an
 -- argument term, given that the term is a function. Errors if the term is not
 -- a function
-mkFunInput :: Id -- ^ Identifier binding the encompassing primitive/blackbox application
+mkFunInput :: Id   -- ^ Identifier binding the encompassing primitive/blackbox application
            -> Term -- ^ The function argument term
-           -> MaybeT NetlistMonad ((Either BlackBoxTemplate Declaration,BlackBoxContext),[Declaration])
+           -> NetlistMonad ((Either BlackBoxTemplate Declaration,BlackBoxContext),[Declaration])
 mkFunInput resId e = do
   let (appE,args) = collectArgs e
-  (bbCtx,dcls) <- lift $ mkBlackBoxContext resId (lefts args)
+  (bbCtx,dcls) <- mkBlackBoxContext resId (lefts args)
   templ <- case appE of
             Prim nm _ -> do
               bbM <- fmap (HashMap.lookup nm) $ Lens.use primitives
@@ -228,7 +207,7 @@ mkFunInput resId e = do
               tcm <- Lens.use tcCache
               eTy <- termType tcm e
               let (_,resTy) = splitFunTys tcm eTy
-              resHTyM <- lift $ coreTypeToHWTypeM resTy
+              resHTyM <- coreTypeToHWTypeM resTy
               case resHTyM of
                 Just resHTy@(SP _ dcArgPairs) -> do
                   let dcI      = dcTag dc - 1
@@ -247,7 +226,7 @@ mkFunInput resId e = do
               normalized <- Lens.use bindings
               case HashMap.lookup fun normalized of
                 Just _ -> do
-                  (Component compName hidden compInps compOutp _) <- lift $ preserveVarEnv $ genComponent fun Nothing
+                  (Component compName hidden compInps compOutp _) <- preserveVarEnv $ genComponent fun Nothing
                   let hiddenAssigns = map (\(i,_) -> (i,Identifier i Nothing)) hidden
                       inpAssigns    = zip (map fst compInps) [ Identifier (pack ("~ARG[" ++ show x ++ "]")) Nothing | x <- [(0::Int)..] ]
                       outpAssign    = (fst compOutp,Identifier (pack "~RESULT") Nothing)
@@ -255,13 +234,13 @@ mkFunInput resId e = do
                   let instLabel     = Text.concat [compName,pack ("_" ++ show i)]
                       instDecl      = InstDecl compName instLabel (outpAssign:hiddenAssigns ++ inpAssigns)
                   return (Right instDecl)
-                Nothing -> return $ error $ $(curLoc) ++ "Cannot make function input for: " ++ showDoc e
-            _ -> return $ error $ $(curLoc) ++ "Cannot make function input for: " ++ showDoc e
+                Nothing -> error $ $(curLoc) ++ "Cannot make function input for: " ++ showDoc e
+            _ -> error $ $(curLoc) ++ "Cannot make function input for: " ++ showDoc e
   case templ of
     Left (_, Left templ') -> let (l,err) = runParse templ'
                              in  if null err
                                     then do
-                                      l'  <- lift $ instantiateSym l
+                                      l'  <- instantiateSym l
                                       l'' <- setClocks bbCtx l'
                                       return ((Left l'',bbCtx),dcls)
                                     else error $ $(curLoc) ++ "\nTemplate:\n" ++ show templ ++ "\nHas errors:\n" ++ show err

--- a/clash-lib/src/CLaSH/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox/Util.hs
@@ -98,7 +98,7 @@ setClocks bc bt = mapM setClocks' bt
     setClocks' (Rst (Just n)) = let (e,_,_)    = bbInputs bc !! n
                                     (rst,rate) = clkSyncId e
                                     rst'       = Text.append rst "_rst"
-                                in  tell [(rst',Reset rate)] >> return (C rst)
+                                in  tell [(rst',Reset rate)] >> return (C rst')
 
     setClocks' e = return e
 

--- a/clash-lib/src/CLaSH/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox/Util.hs
@@ -43,7 +43,7 @@ verifyBlackBoxContext bbCtx = all verify'
     verify' (Typ (Just n))  = n < length (bbInputs bbCtx)
     verify' (TypM (Just n)) = n < length (bbInputs bbCtx)
     verify' (Err (Just n))  = n < length (bbInputs bbCtx)
-    verify' (D (Decl n l')) = case indexMaybe (bbFunctions bbCtx) n of
+    verify' (D (Decl n l')) = case IntMap.lookup n (bbFunctions bbCtx) of
                                 Just _ -> all (\(x,y) -> verifyBlackBoxContext bbCtx x &&
                                                          verifyBlackBoxContext bbCtx y) l'
                                 _      -> False
@@ -125,7 +125,7 @@ renderElem :: Backend backend
 renderElem b (D (Decl n (l:ls))) = do
     (o,oTy,_) <- syncIdToSyncExpr <$> combineM (lineToIdentifier b) (return . lineToType b) l
     is <- mapM (fmap syncIdToSyncExpr . combineM (lineToIdentifier b) (return . lineToType b)) ls
-    let Just (Just (templ,pCtx)) = indexMaybe (bbFunctions b) n
+    let Just (templ,pCtx)    = IntMap.lookup n (bbFunctions b)
         b' = pCtx { bbResult = (o,oTy), bbInputs = bbInputs pCtx ++ is }
     templ' <- case templ of
                 Left t  -> return t

--- a/clash-lib/src/CLaSH/Netlist/Types.hs
+++ b/clash-lib/src/CLaSH/Netlist/Types.hs
@@ -12,6 +12,7 @@ import Control.Monad.State                  (MonadIO, MonadState, StateT)
 import Control.Monad.Writer                 (MonadWriter, WriterT)
 import Data.Hashable
 import Data.HashMap.Lazy                    (HashMap)
+import Data.IntMap.Lazy                     (IntMap, empty)
 import qualified Data.Text                  as S
 import Data.Text.Lazy                       (Text, pack)
 import GHC.Generics                         (Generic)
@@ -168,7 +169,7 @@ data BlackBoxContext
   = Context
   { bbResult    :: (SyncExpr,HWType) -- ^ Result name and type
   , bbInputs    :: [(SyncExpr,HWType,Bool)] -- ^ Argument names, types, and whether it is a literal
-  , bbFunctions :: [Maybe (Either BlackBoxTemplate Declaration,BlackBoxContext)]
+  , bbFunctions :: IntMap (Either BlackBoxTemplate Declaration,BlackBoxContext)
   -- ^ Function arguments (subset of inputs):
   --
   -- * (Blackbox Template,Partial Blackbox Concext)
@@ -176,7 +177,7 @@ data BlackBoxContext
   deriving Show
 
 emptyBBContext :: BlackBoxContext
-emptyBBContext = Context (Left $ Identifier (pack "__EMPTY__") Nothing, Void) [] []
+emptyBBContext = Context (Left $ Identifier (pack "__EMPTY__") Nothing, Void) [] empty
 
 -- | Either the name of the identifier, or a tuple of the identifier and the
 -- corresponding clock

--- a/clash-lib/src/CLaSH/Netlist/Types.hs
+++ b/clash-lib/src/CLaSH/Netlist/Types.hs
@@ -167,9 +167,8 @@ data Bit
 data BlackBoxContext
   = Context
   { bbResult    :: (SyncExpr,HWType) -- ^ Result name and type
-  , bbInputs    :: [(SyncExpr,HWType)] -- ^ Argument names and types
-  , bbLitInputs :: [Expr] -- ^ Literal arguments (subset of inputs)
-  , bbFunInputs :: [(Either BlackBoxTemplate Declaration,BlackBoxContext)]
+  , bbInputs    :: [(SyncExpr,HWType,Bool)] -- ^ Argument names, types, and whether it is a literal
+  , bbFunctions :: [Maybe (Either BlackBoxTemplate Declaration,BlackBoxContext)]
   -- ^ Function arguments (subset of inputs):
   --
   -- * (Blackbox Template,Partial Blackbox Concext)
@@ -177,7 +176,7 @@ data BlackBoxContext
   deriving Show
 
 emptyBBContext :: BlackBoxContext
-emptyBBContext = Context (Left $ Identifier (pack "__EMPTY__") Nothing, Void) [] [] []
+emptyBBContext = Context (Left $ Identifier (pack "__EMPTY__") Nothing, Void) [] []
 
 -- | Either the name of the identifier, or a tuple of the identifier and the
 -- corresponding clock

--- a/clash-lib/src/CLaSH/Netlist/Types.hs
+++ b/clash-lib/src/CLaSH/Netlist/Types.hs
@@ -126,7 +126,7 @@ data Declaration
   -- * List of: (Maybe expression scrutinized expression is compared with,RHS of alternative)
   | InstDecl Identifier Identifier [(Identifier,Expr)] -- ^ Instantiation of another component
   | BlackBoxD S.Text BlackBoxTemplate BlackBoxContext -- ^ Instantiation of blackbox declaration
-  | NetDecl Identifier HWType (Maybe Expr) -- ^ Signal declaration
+  | NetDecl Identifier HWType -- ^ Signal declaration
   deriving Show
 
 instance NFData Declaration where

--- a/clash-lib/src/CLaSH/Netlist/Util.hs
+++ b/clash-lib/src/CLaSH/Netlist/Util.hs
@@ -203,6 +203,15 @@ termHWType loc e = do
   ty <- termType m e
   unsafeCoreTypeToHWTypeM loc ty
 
+-- | Gives the HWType corresponding to a term. Returns 'Nothing' if the term has
+-- a Core type that is not translatable to a HWType.
+termHWTypeM :: Term
+            -> NetlistMonad (Maybe HWType)
+termHWTypeM e = do
+  m  <- Lens.use tcCache
+  ty <- termType m e
+  coreTypeToHWTypeM ty
+
 -- | Turns a Core variable reference to a Netlist expression. Errors if the term
 -- is not a variable.
 varToExpr :: Term

--- a/clash-systemverilog/primitives/CLaSH.Driver.TestbenchGen.json
+++ b/clash-systemverilog/primitives/CLaSH.Driver.TestbenchGen.json
@@ -45,9 +45,13 @@ end
     , "templateD" :
 "always_comb begin
 // pragma translate_off
-  #~LIT[1]
+  ~RESULT = 1'b0;
+  #~LIT[0] forever begin
 // pragma translate_on
-  ~RESULT = ~LIT[0];
+    ~RESULT = 1'b1;
+// pragma translate_off
+  end
+// pragma translate_on
 end"
     }
   }

--- a/clash-systemverilog/primitives/CLaSH.Driver.TestbenchGen.json
+++ b/clash-systemverilog/primitives/CLaSH.Driver.TestbenchGen.json
@@ -43,15 +43,12 @@ end
 , { "BlackBox" :
     { "name"      : "CLaSH.Driver.TestbenchGen.finishedGen"
     , "templateD" :
-"always_comb begin
+"always begin
 // pragma translate_off
-  ~RESULT = 1'b0;
-  #~LIT[0] forever begin
+  ~RESULT <= 1'b0;
+  #~LIT[0]
 // pragma translate_on
-    ~RESULT = 1'b1;
-// pragma translate_off
-  end
-// pragma translate_on
+  ~RESULT = 1'b1;
 end"
     }
   }

--- a/clash-systemverilog/primitives/CLaSH.Prelude.BlockRam.json
+++ b/clash-systemverilog/primitives/CLaSH.Prelude.BlockRam.json
@@ -1,14 +1,14 @@
 [ { "BlackBox" :
-    { "name"      : "CLaSH.Prelude.BlockRam.cblockRam"
-    , "comment"   :
-    "cblockRam :: (KnownNat n, KnownNat m) -- (ARG[0],ARG[1])
-          => SClock clk                    -- clk,  ARG[2]
-          -> Vec n a                       -- init, ARG[3]
-          -> CSignal clk (Unsigned m)      -- wr,   ARG[4]
-          -> CSignal clk (Unsigned m)      -- rd,   ARG[5]
-          -> CSignal clk Bool              -- wren, ARG[6]
-          -> CSignal clk a                 -- din,  ARG[7]
-          -> CSignal clk a"
+    { "name" : "CLaSH.Prelude.BlockRam.cblockRam"
+    , "type" :
+"cblockRam :: (KnownNat n, KnownNat m) -- (ARG[0],ARG[1])
+      => SClock clk                    -- clk,  ARG[2]
+      -> Vec n a                       -- init, ARG[3]
+      -> CSignal clk (Unsigned m)      -- wr,   ARG[4]
+      -> CSignal clk (Unsigned m)      -- rd,   ARG[5]
+      -> CSignal clk Bool              -- wren, ARG[6]
+      -> CSignal clk a                 -- din,  ARG[7]
+      -> CSignal clk a"
     , "templateD" :
 "// blockRam
 ~SIGD[~SYM[0]][3];

--- a/clash-systemverilog/primitives/CLaSH.Prelude.Testbench.json
+++ b/clash-systemverilog/primitives/CLaSH.Prelude.Testbench.json
@@ -1,11 +1,11 @@
 [ { "BlackBox" :
-    { "name"      : "CLaSH.Prelude.Testbench.csassert"
-    , "comment"   :
-    "csassert :: (Eq a,Show a) -- (ARG[0],ARG[1])
-         => CSignal t a -- ^ Checked value (ARG[2])
-         -> CSignal t a -- ^ Expected value (ARG[3])
-         -> CSignal t b -- ^ Return valued (ARG[4])
-         -> CSignal t b"
+    { "name" : "CLaSH.Prelude.Testbench.csassert"
+    , "type" :
+"csassert :: (Eq a,Show a) -- (ARG[0],ARG[1])
+     => CSignal t a -- ^ Checked value (ARG[2])
+     -> CSignal t a -- ^ Expected value (ARG[3])
+     -> CSignal t b -- ^ Return valued (ARG[4])
+     -> CSignal t b"
     , "templateD" :
 "// assert
 // pragma translate_off

--- a/clash-systemverilog/primitives/CLaSH.Promoted.Nat.json
+++ b/clash-systemverilog/primitives/CLaSH.Promoted.Nat.json
@@ -1,10 +1,12 @@
 [ { "BlackBox" :
     { "name"      : "CLaSH.Promoted.Nat.SNat"
+    , "type"      : "SNat :: KnownNat n => Proxy n -> SNat n"
     , "templateE" : "~LIT[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Promoted.Nat.snatToInteger"
+    , "type"      : "snatToInteger :: SNat n -> Integer"
     , "templateE" : "~LIT[0]"
     }
   }

--- a/clash-systemverilog/primitives/CLaSH.Promoted.Symbol.json
+++ b/clash-systemverilog/primitives/CLaSH.Promoted.Symbol.json
@@ -1,10 +1,12 @@
 [ { "BlackBox" :
     { "name"      : "CLaSH.Promoted.Symbol.SSymbol"
+    , "type"      : "SSymbol :: KnownNat n => Proxy n -> SSymbol n"
     , "templateE" : "~LIT[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Promoted.Symbol.symbolToString"
+    , "type"      : "symbolToString :: SSymbol n -> String"
     , "templateE" : "~LIT[0]"
     }
   }

--- a/clash-systemverilog/primitives/CLaSH.Signal.Explicit.json
+++ b/clash-systemverilog/primitives/CLaSH.Signal.Explicit.json
@@ -1,5 +1,10 @@
 [ { "BlackBox" :
     { "name"      : "CLaSH.Signal.Explicit.veryUnsafeSynchronizer"
+    , "type" :
+"veryUnsafeSynchronizer :: SClock clk1
+                        -> SClock clk2
+                        -> CSignal clk1 a -- ARG[2]
+                        -> CSignal clk2 a"
     , "templateE" : "~ARG[2]"
     }
   }

--- a/clash-systemverilog/primitives/CLaSH.Signal.Internal.json
+++ b/clash-systemverilog/primitives/CLaSH.Signal.Internal.json
@@ -1,10 +1,10 @@
 [ { "BlackBox" :
-    { "name"      : "CLaSH.Signal.Internal.register#"
-    , "comment"   :
-    "register# :: SClock clk     -- ARG[0]
-               -> a              -- ARG[1]
-               -> CSignal clk a  -- ARG[2]
-               -> CSignal clk a"
+    { "name" : "CLaSH.Signal.Internal.register#"
+    , "type" :
+"register# :: SClock clk     -- ARG[0]
+           -> a              -- ARG[1]
+           -> CSignal clk a  -- ARG[2]
+           -> CSignal clk a"
     , "templateD" :
 "~SIGD[~SYM[0]][2];
 
@@ -19,13 +19,13 @@ assign ~RESULT = ~SYM[0];"
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Signal.Internal.regEn#"
-    , "comment"   :
-    "regEn# :: SClock clk       -- ARG[0]
-            -> a                -- ARG[1]
-            -> CSignal clk Bool -- ARG[2]
-            -> CSignal clk a    -- ARG[3]
-            -> CSignal clk a"
+    { "name" : "CLaSH.Signal.Internal.regEn#"
+    , "type" :
+"regEn# :: SClock clk       -- ARG[0]
+        -> a                -- ARG[1]
+        -> CSignal clk Bool -- ARG[2]
+        -> CSignal clk a    -- ARG[3]
+        -> CSignal clk a"
     , "templateD" :
 "~SIGD[~SYM[0]][3];
 

--- a/clash-systemverilog/primitives/CLaSH.Sized.Internal.BitVector.json
+++ b/clash-systemverilog/primitives/CLaSH.Sized.Internal.BitVector.json
@@ -1,50 +1,58 @@
 [ { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.size#"
+    , "type"      : "size# :: KnownNat n => BitVector n -> Int"
     , "templateE" : "~LIT[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.maxIndex#"
+    , "type"      : "maxIndex# :: KnownNat n => BitVector n -> Int"
     , "templateE" : "~LIT[0] - 1"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.high"
+    , "type"      : "high :: Bit"
     , "templateE" : "1'b1"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.low"
+    , "type"      : "low :: Bit"
     , "templateE" : "1'b0"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.++#"
+    , "type"      : "(++#) :: KnownNat m => BitVector n -> BitVector m -> BitVector (n + m)"
     , "templateE" : "{~ARG[1],~ARG[2]}"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.reduceAnd#"
+    , "type"      : "reduceAnd# :: KnownNat n => BitVector n -> BitVector 1"
     , "templateE" : "& (~ARG[1])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.reduceOr#"
+    , "type"      : "reduceOr# :: BitVector n -> BitVector 1"
     , "templateE" : "| (~ARG[0])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.reduceXor#"
+    , "type"      : "reduceXor# :: BitVector n -> BitVector 1"
     , "templateE" : "^ (~ARG[0])"
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Sized.Internal.BitVector.index#"
-    , "comment"   :
-    "index# :: KnownNat n  -- ARG[0]
-            => BitVector n -- ARG[1]
-            -> Int         -- ARG[2]
-            -> Bit"
+    { "name" : "CLaSH.Sized.Internal.BitVector.index#"
+    , "type" :
+"index# :: KnownNat n  -- ARG[0]
+        => BitVector n -- ARG[1]
+        -> Int         -- ARG[2]
+        -> Bit"
     , "templateD" :
 "// index
 ~SIGD[~SYM[0]][1];
@@ -69,6 +77,12 @@ end
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.replaceBit#"
+    , "type" :
+"replaceBit# :: KnownNat n  -- ARG[0]
+             => BitVector n -- ARG[1]
+             -> Int         -- ARG[2]
+             -> Bit         -- ARG[3]
+             -> BitVector n"
     , "templateD" :
 "// replaceBit
 ~SIGD[~SYM[0]][2];
@@ -93,13 +107,13 @@ assign ~RESULT = ~SYM[1];"
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Sized.Internal.BitVector.setSlice#"
-    , "comment"   :
-    "setSlice# :: BitVector (m + 1 + i) -- ARG[0]
-               -> SNat m                -- ARG[1]
-               -> SNat n                -- ARG[2]
-               -> BitVector (m + 1 - n) -- ARG[3]
-               -> BitVector (m + 1 + i)"
+    { "name" : "CLaSH.Sized.Internal.BitVector.setSlice#"
+    , "type" :
+"setSlice# :: BitVector (m + 1 + i) -- ARG[0]
+           -> SNat m                -- ARG[1]
+           -> SNat n                -- ARG[2]
+           -> BitVector (m + 1 - n) -- ARG[3]
+           -> BitVector (m + 1 + i)"
     , "templateD" :
 "// setSlice
 ~SIGD[~SYM[0]][0];
@@ -113,12 +127,12 @@ assign ~RESULT = ~SYM[0];"
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Sized.Internal.BitVector.slice#"
-    , "comment"   :
-    "slice# :: BitVector (m + 1 + i) -- ARG[0]
-            -> SNat m                -- ARG[1]
-            -> SNat n                -- ARG[2]
-            -> BitVector (m + 1 - n)"
+    { "name" : "CLaSH.Sized.Internal.BitVector.slice#"
+    , "type" :
+"slice# :: BitVector (m + 1 + i) -- ARG[0]
+        -> SNat m                -- ARG[1]
+        -> SNat n                -- ARG[2]
+        -> BitVector (m + 1 - n)"
     , "templateD" :
 "// slice
 ~SIGD[~SYM[0]][0];
@@ -127,11 +141,11 @@ assign ~RESULT = ~SYM[1][~LIT[1] : ~LIT[2]];"
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Sized.Internal.BitVector.split#"
-    , "comment"   :
-    "split# :: KnownNat n        -- ARG[0]
-            => BitVector (m + n) -- ARG[1]
-            -> (BitVector m, BitVector n)"
+    { "name" : "CLaSH.Sized.Internal.BitVector.split#"
+    , "type" :
+"split# :: KnownNat n        -- ARG[0]
+        => BitVector (m + n) -- ARG[1]
+        -> (BitVector m, BitVector n)"
     , "templateD" :
 "// split
 ~SIGD[~SYM[0]][1];
@@ -142,11 +156,11 @@ assign ~RESULT = '{ ~SYM[0][$high(~SYM[0]) : ~LIT[0]]
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Sized.Internal.BitVector.msb#"
-    , "comment"   :
-    "msb# :: KnownNat n  -- ARG[0]
-          => BitVector n -- ARG[1]
-          -> Bit"
+    { "name" : "CLaSH.Sized.Internal.BitVector.msb#"
+    , "type" :
+"msb# :: KnownNat n  -- ARG[0]
+      => BitVector n -- ARG[1]
+      -> Bit"
     , "templateD" :
 "// msb
 ~SIGD[~SYM[0]][1];
@@ -155,10 +169,10 @@ assign ~RESULT = ~SYM[0][~LIT[0]-1];"
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Sized.Internal.BitVector.lsb#"
-    , "comment"   :
-    "lsb# :: BitVector n -- ARG[0]
-          -> Bit"
+    { "name" : "CLaSH.Sized.Internal.BitVector.lsb#"
+    , "type" :
+"lsb# :: BitVector n -- ARG[0]
+      -> Bit"
     , "templateD" :
 "// lsb
 ~SIGD[~SYM[0]][0];
@@ -168,138 +182,163 @@ assign ~RESULT = ~SYM[0][0];"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.eq#"
+    , "type"      : "eq# :: BitVector n -> BitVector n -> Bool"
     , "templateE" : "~ARG[0] == ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.neq#"
+    , "type"      : "neq# :: BitVector n -> BitVector n -> Bool"
     , "templateE" : "~ARG[0] != ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.lt#"
+    , "type"      : "lt# :: BitVector n -> BitVector n -> Bool"
     , "templateE" : "~ARG[0] < ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.ge#"
+    , "type"      : "ge# :: BitVector n -> BitVector n -> Bool"
     , "templateE" : "~ARG[0] >= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.gt#"
+    , "type"      : "gt# :: BitVector n -> BitVector n -> Bool"
     , "templateE" : "~ARG[0] > ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.le#"
+    , "type"      : "le# :: BitVector n -> BitVector n -> Bool"
     , "templateE" : "~ARG[0] <= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.minBound#"
-    , "comment"   : "Generates incorrect VDHL for n=0"
+    , "type"      : "minBound# :: KnownNat n => BitVector n"
     , "templateE" : "~LIT[0]'d0"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.maxBound#"
-    , "comment"   : "Generates incorrect VDHL for n=0"
+    , "type"      : "maxBound# :: KnownNat n => BitVector n"
     , "templateE" : "{~LIT[0] {1'b1}}"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.+#"
+    , "type"      : "(+#) :: KnownNat n => BitVector n -> BitVector n -> BitVector n"
     , "templateE" : "~ARG[1] + ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.-#"
+    , "type"      : "(-#) :: KnownNat n => BitVector n -> BitVector n -> BitVector n"
     , "templateE" : "~ARG[1] - ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.*#"
+    , "type"      : "(*#) :: KnownNat n => BitVector n -> BitVector n -> BitVector n"
     , "templateE" : "~ARG[1] * ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.negate#"
+    , "type"      : "negate# :: KnownNat n => BitVector n -> BitVector n"
     , "templateE" : "-~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.fromInteger#"
+    , "type"      : "fromInteger# :: KnownNat n => Integer -> BitVector n"
     , "templateE" : "$unsigned(~ARG[1])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.plus#"
+    , "type"      : "plus# :: KnownNat (Max m n + 1) => BitVector m -> BitVector n -> BitVector (Max m n + 1)"
     , "templateE" : "~ARG[1] + ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.minus#"
+    , "type"      : "minus# :: KnownNat (Max m n + 1) => BitVector m -> BitVector n -> BitVector (Max m n + 1)"
     , "templateE" : "~ARG[1] - ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.times#"
+    , "type"      : "times# :: KnownNat (m + n) => BitVector m -> BitVector n -> BitVector (m + n)"
     , "templateE" : "~ARG[1] * ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.quot#"
+    , "type"      : "quot# :: BitVector n -> BitVector n -> BitVector n"
     , "templateE" : "~ARG[1]) / ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.rem#"
+    , "type"      : "rem# :: BitVector n -> BitVector n -> BitVector n"
     , "templateE" : "~ARG[1] % ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.mod#"
+    , "type"      : "mod# :: BitVector n -> BitVector n -> BitVector n"
     , "templateE" : "~ARG[1] % ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.toInteger#"
+    , "type"      : "toInteger# :: BitVector n -> Integer"
     , "templateE" : "$unsigned(~ARG[0])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.and#"
+    , "type"      : "and# :: BitVector n -> BitVector n -> BitVector n"
     , "templateE" : "~ARG[0] & ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.or#"
+    , "type"      : "or# :: BitVector n -> BitVector n -> BitVector n"
     , "templateE" : "~ARG[0] | ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.xor#"
+    , "type"      : "xor# :: BitVector n -> BitVector n -> BitVector n"
     , "templateE" : "~ARG[0] ^ ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.complement#"
+    , "type"      : "complement# :: KnownNat n => BitVector n -> BitVector n"
     , "templateE" : "~ ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.shiftL#"
+    , "type"      : "shiftL# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "templateE" : "~ARG[1] << ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.shiftR#"
+    , "type"      : "shiftR# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "templateE" : "~ARG[1] >> ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.rotateL#"
+    , "type"      : "rotateL# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "templateD" :
 "// rotateL
 logic [2*~LIT[0]-1:0] ~SYM[0];
@@ -309,6 +348,7 @@ assign ~RESULT = ~SYM[0][~LIT[1]-1 : 0];"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.rotateR#"
+    , "type"      : "rotateR# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "templateD" :
 "// rotateR
 logic [2*~LIT[0]-1:0] ~SYM[0];
@@ -318,6 +358,7 @@ assign ~RESULT = ~SYM[0][~LIT[1]-1 : 0];"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.resize#"
+    , "type"      : "resize# :: KnownNat m => BitVector n -> BitVector m"
     , "templateE" : "$unsigned(~ARG[1])"
     }
   }

--- a/clash-systemverilog/primitives/CLaSH.Sized.Internal.Index.json
+++ b/clash-systemverilog/primitives/CLaSH.Sized.Internal.Index.json
@@ -1,75 +1,90 @@
 [ { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.eq#"
+    , "type"      : "eq# :: Index n -> Index n -> Bool"
     , "templateE" : "~ARG[0] == ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.neq#"
+    , "type"      : "neq# :: Index n -> Index n -> Bool"
     , "templateE" : "~ARG[0] != ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.lt#"
+    , "type"      : "lt# :: Index n -> Index n -> Bool"
     , "templateE" : "~ARG[0] < ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.ge#"
+    , "type"      : "ge# :: Index n -> Index n -> Bool"
     , "templateE" : "~ARG[0] >= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.gt#"
+    , "type"      : "gt# :: Index n -> Index n -> Bool"
     , "templateE" : "~ARG[0] > ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.le#"
+    , "type"      : "le# :: Index n -> Index n -> Bool"
     , "templateE" : "~ARG[0] <= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.maxBound#"
+    , "type"      : "maxBound# :: KnownNat n => Index n"
     , "templateE" : "~LIT[0]-1"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.+#"
+    , "type"      : "(+#) :: KnownNat n => Index n -> Index n -> Index n"
     , "templateE" : "~ARG[1] + ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.-#"
+    , "type"      : "(-#) :: KnownNat n => Index n -> Index n -> Index n"
     , "templateE" : "~ARG[1] - ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.*#"
+    , "type"      : "(*#) :: KnownNat n => Index n -> Index n -> Index n"
     , "templateE" : "~ARG[1] * ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.fromInteger#"
+    , "type"      : "fromInteger# :: KnownNat n => Integer -> Index n"
     , "templateE" : "$unsigned(~ARG[1])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.quot#"
+    , "type"      : "quot# :: KnownNat n => Index n -> Index n -> Index n"
     , "templateE" : "~ARG[1] / ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.rem#"
+    , "type"      : "rem# :: KnownNat n => Index n -> Index n -> Index n"
     , "templateE" : "~ARG[1] % ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.mod#"
+    , "type"      : "mod# :: KnownNat n => Index n -> Index n -> Index n"
     , "templateE" : "~ARG[1] % ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.toInteger#"
+    , "type"      : "toInteger# :: Index n -> Integer"
     , "templateE" : "$unsigned(~ARG[0])"
     }
   }

--- a/clash-systemverilog/primitives/CLaSH.Sized.Internal.Signed.json
+++ b/clash-systemverilog/primitives/CLaSH.Sized.Internal.Signed.json
@@ -1,119 +1,140 @@
 [ { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Internal.Signed.size#"
+    , "type"      : "size# :: KnownNat n => Signed n -> Int"
     , "templateE" : "~LIT[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.pack#"
+    , "type"      : "pack# :: KnownNat n => Signed n -> BitVector n"
     , "templateE" : "~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.unpack#"
+    , "type"      : "unpack# :: KnownNat n => BitVector n -> Signed n"
     , "templateE" : "~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.eq#"
+    , "type"      : "eq# :: Signed n -> Signed n -> Bool"
     , "templateE" : "~ARG[0] == ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.neq#"
+    , "type"      : "neq# :: Signed n -> Signed n -> Bool"
     , "templateE" : "~ARG[0] != ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.lt#"
+    , "type"      : "lt# :: Signed n -> Signed n -> Bool"
     , "templateE" : "~ARG[0] < ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.ge#"
+    , "type"      : "ge# :: Signed n -> Signed n -> Bool"
     , "templateE" : "~ARG[0] >= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.gt#"
+    , "type"      : "gt# :: Signed n -> Signed n -> Bool"
     , "templateE" : "~ARG[0] > ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.le#"
+    , "type"      : "le# :: Signed n -> Signed n -> Bool"
     , "templateE" : "~ARG[0] <= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.minBound#"
-    , "comment"   : "Generates incorrect VDHL for n=0"
-    , "comment2"  : "the quantification with signed gives the array an ascending index"
+    , "type"      : "minBound# :: KnownNat n => Signed n"
+    , "comment"   : "Generates incorrect SV for n=0"
     , "templateE" : "{1'b1, {(~LIT[0]-1) {1'b0}}}"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.maxBound#"
-    , "comment"   : "Generates incorrect VDHL for n=0"
-    , "comment2"  : "the quantification with signed gives the array an ascending index"
+    , "type"      : "maxBound# :: KnownNat n => Signed n"
+    , "comment"   : "Generates incorrect SV for n=0"
     , "templateE" : "{1'b0, {(~LIT[0]-1) {1'b1}}}"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.+#"
+    , "type"      : "(+#) :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "templateE" : "~ARG[1] + ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.-#"
+    , "type"      : "(-#) :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "templateE" : "~ARG[1] - ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.*#"
+    , "type"      : "(*#) :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "templateE" : "~ARG[1] * ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.negate#"
+    , "type"      : "negate# :: KnownNat n => Signed n -> Signed n"
     , "templateE" : "-~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.abs#"
+    , "type"      : "abs# :: KnownNat n => Signed n -> Signed n"
     , "templateE" : "(~ARG[1] < ~LIT[0]'sd0) ? -~ARG[1] : ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.fromInteger#"
+    , "type"      : "fromInteger# :: KnownNat n => Integer -> Signed (n :: Nat)"
     , "templateE" : "$signed(~ARG[1])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.plus#"
+    , "type"      : "plus# :: KnownNat (1 + Max m n) => Signed m -> Signed n -> Signed (1 + Max m n)"
     , "templateE" : "~ARG[1] + ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.minus#"
+    , "type"      : "minus# :: KnownNat (1 + Max m n) => Signed m -> Signed n -> Signed (1 + Max m n)"
     , "templateE" : "~ARG[1] - ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.times#"
+    , "type"      : "times# :: KnownNat (m + n) => Signed m -> Signed n -> Signed (m + n)"
     , "templateE" : "~ARG[1] * ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.quot#"
+    , "type"      : "quot# :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "templateE" : "~ARG[1] / ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.rem#"
+    , "type"      : "rem# :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "templateE" : "~ARG[1] % ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.div#"
+    , "type"      : "div# :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "templateD" :
 "// divInt
 ~SIGD[~SYM[0]][1];
@@ -131,6 +152,7 @@ assign ~RESULT = (~SYM[1][~LIT[0]-1] == ~SYM[2][~LIT[0]-1]) ? ~SYM[0] : ~SYM[0] 
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.mod#"
+    , "type"      : "mod# :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "templateD" :
 "// modSigned
 ~SIGD[~SYM[0]][1];
@@ -150,41 +172,49 @@ assign ~RESULT = (~SYM[1][~LIT[0]-1] == ~SYM[2][~LIT[0]-1]) ?
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.toInteger#"
+    , "type"      : "toInteger# :: Signed n -> Integer"
     , "templateE" : "$signed(~ARG[0])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.and#"
+    , "type"      : "and# :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "templateE" : "~ARG[1] & ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.or#"
+    , "type"      : "or# :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "templateE" : "~ARG[1] | ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.xor#"
+    , "type"      : "xor# :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "templateE" : "~ARG[1] ^ ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.complement#"
+    , "type"      : "complement# :: KnownNat n => Signed n -> Signed n"
     , "templateE" : "~ ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.shiftL#"
+    , "type"      : "shiftL# :: KnownNat n => Signed n -> Int -> Signed n"
     , "templateE" : "~ARG[1] <<< ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.shiftR#"
+    , "type"      : "shiftR# :: KnownNat n => Signed n -> Int -> Signed n"
     , "templateE" : "~ARG[1] >>> ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.rotateL#"
+    , "type"      : "rotateL# :: KnownNat n => Signed n -> Int -> Signed n"
     , "templateD" :
 "// rotateL
 logic [2*~LIT[0]-1:0] ~SYM[0];
@@ -194,6 +224,7 @@ assign ~RESULT = $signed(~SYM[0][~LIT[1]-1 : 0]);"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.rotateR#"
+    , "type"      : "rotateR# :: KnownNat n => Signed n -> Int -> Signed n"
     , "templateD" :
 "// rotateR
 logic [2*~LIT[0]-1:0] ~SYM[0];
@@ -203,6 +234,7 @@ assign ~RESULT = $signed(~SYM[0][~LIT[1]-1 : 0]);"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.resize#"
+    , "type"      : "resize# :: (KnownNat n, KnownNat m) => Signed n -> Signed m"
     , "comment"   : "Back-end should only use this code when the result is smaller than the argument"
     , "templateD" :
 "// truncate, sign preserving
@@ -213,6 +245,7 @@ assign ~RESULT = $signed({~SYM[0][~LIT[0]-1],~SYM[0][(~LIT[1]-2):0]});"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.truncateB#"
+    , "type"      : "truncateB# :: KnownNat m => Signed (n + m) -> Signed m"
     , "templateE" : "$signed(~ARG[1])"
     }
   }

--- a/clash-systemverilog/primitives/CLaSH.Sized.Internal.Signed.json
+++ b/clash-systemverilog/primitives/CLaSH.Sized.Internal.Signed.json
@@ -237,10 +237,18 @@ assign ~RESULT = $signed(~SYM[0][~LIT[1]-1 : 0]);"
     , "type"      : "resize# :: (KnownNat n, KnownNat m) => Signed n -> Signed m"
     , "comment"   : "Back-end should only use this code when the result is smaller than the argument"
     , "templateD" :
-"// truncate, sign preserving
-~SIGD[~SYM[0]][2];
-assign ~SYM[0] = ~ARG[2];
-assign ~RESULT = $signed({~SYM[0][~LIT[0]-1],~SYM[0][(~LIT[1]-2):0]});"
+"// resize
+generate
+  if (~LIT[1] < ~LIT[0]) begin
+    // truncate, sign preserving
+    ~SIGD[~SYM[0]][2];
+    assign ~SYM[0] = ~ARG[2];
+    assign ~RESULT = $signed({~SYM[0][~LIT[0]-1],~SYM[0][(~LIT[1]-2):0]});
+  end else begin
+    // sign-extend
+    assign ~RESULT = $signed(~ARG[2]);
+  end
+endgenerate"
     }
   }
 , { "BlackBox" :

--- a/clash-systemverilog/primitives/CLaSH.Sized.Internal.Unsigned.json
+++ b/clash-systemverilog/primitives/CLaSH.Sized.Internal.Unsigned.json
@@ -1,152 +1,180 @@
 [ { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.size#"
+    , "type"      : "size# :: KnownNat n => Unsigned n -> Int"
     , "templateE" : "~LIT[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.pack#"
+    , "type"      : "pack# :: Unsigned n -> BitVector n"
     , "templateE" : "~ARG[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.unpack#"
+    , "type"      : "unpack# :: BitVector n -> Unsigned n"
     , "templateE" : "~ARG[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.eq#"
+    , "type"      : "eq# :: Unsigned n -> Unsigned n -> Bool"
     , "templateE" : "~ARG[0] == ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.neq#"
+    , "type"      : "neq# :: Unsigned n -> Unsigned n -> Bool"
     , "templateE" : "~ARG[0] != ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.lt#"
+    , "type"      : "lt# :: Unsigned n -> Unsigned n -> Bool"
     , "templateE" : "~ARG[0] < ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.ge#"
+    , "type"      : "ge# :: Unsigned n -> Unsigned n -> Bool"
     , "templateE" : "~ARG[0] >= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.gt#"
+    , "type"      : "gt# :: Unsigned n -> Unsigned n -> Bool"
     , "templateE" : "~ARG[0] > ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.le#"
+    , "type"      : "le# :: Unsigned n -> Unsigned n -> Bool"
     , "templateE" : "~ARG[0] <= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.minBound#"
-    , "comment"   : "Generates incorrect VDHL for n=0"
+    , "type"      : "minBound# :: KnownNat n => Unsigned n"
     , "templateE" : "~LIT[0]'d0"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.maxBound#"
-    , "comment"   : "Generates incorrect VDHL for n=0"
-    , "templateE" : "{~LIT[0]{1'b1}}"
+    , "type"      : "maxBound# :: KnownNat n => Unsigned n"
+    , "templateE" : "{~LIT[0] {1'b1}}"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.+#"
+    , "type"      : "(+#) :: KnownNat n => Unsigned n -> Unsigned n -> Unsigned n"
     , "templateE" : "~ARG[1] + ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.-#"
+    , "type"      : "(-#) :: KnownNat n => Unsigned n -> Unsigned n -> Unsigned n"
     , "templateE" : "~ARG[1] - ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.*#"
+    , "type"      : "(*#) :: KnownNat n => Unsigned n -> Unsigned n -> Unsigned n"
     , "templateE" : "~ARG[1] * ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.negate#"
+    , "type"      : "negate# :: KnownNat n => Unsigned n -> Unsigned n"
     , "templateE" : "- ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.fromInteger#"
+    , "type"      : "fromInteger# :: KnownNat n => Integer -> Unsigned n"
     , "templateE" : "$unsigned(~ARG[1])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.plus#"
+    , "type"      : "plus# :: KnownNat (1 + Max m n) => Unsigned m -> Unsigned n -> Unsigned (1 + Max m n)"
     , "templateE" : "~ARG[1] + ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.minus#"
+    , "type"      : "minus# :: KnownNat (1 + Max m n) => Unsigned m -> Unsigned n -> Unsigned (1 + Max m n)"
     , "templateE" : "~ARG[1] - ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.times#"
+    , "type"      : "times# :: KnownNat (m + n) => Unsigned m -> Unsigned n -> Unsigned (m + n)"
     , "templateE" : "~ARG[1] * ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.quot#"
+    , "type"      : "quot# :: Unsigned n -> Unsigned n -> Unsigned n"
     , "templateE" : "~ARG[1] / ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.rem#"
+    , "type"      : "rem# :: Unsigned n -> Unsigned n -> Unsigned n"
     , "templateE" : "~ARG[1] % ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.mod#"
+    , "type"      : "mod# :: Unsigned n -> Unsigned n -> Unsigned n"
     , "templateE" : "~ARG[1] % ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.toInteger#"
+    , "type"      : "toInteger# :: Unsigned n -> Integer"
     , "templateE" : "$unsigned(~ARG[0])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.and#"
+    , "type"      : "and# :: Unsigned n -> Unsigned n -> Unsigned n"
     , "templateE" : "~ARG[0] & ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.or#"
+    , "type"      : "or# :: Unsigned n -> Unsigned n -> Unsigned n"
     , "templateE" : "~ARG[0] | ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.xor#"
+    , "type"      : "xor# :: Unsigned n -> Unsigned n -> Unsigned n"
     , "templateE" : "~ARG[0] ^ ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.complement#"
+    , "type"      : "complement# :: KnownNat n => Unsigned n -> Unsigned n"
     , "templateE" : "~ ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.shiftL#"
+    , "type"      : "shiftL# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "templateE" : "~ARG[1] << ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.shiftR#"
+    , "type"      : "shiftR# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "templateE" : "~ARG[1] >> ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.rotateL#"
+    , "type"      : "rotateL# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "templateD" :
 "// rotateL
 logic [2*~LIT[0]-1:0] ~SYM[0];
@@ -156,6 +184,7 @@ assign ~RESULT = ~SYM[0][~LIT[1]-1 : 0];"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.rotateR#"
+    , "type"      : "rotateR# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "templateD" :
 "// rotateR
 logic [2*~LIT[0]-1:0] ~SYM[0];
@@ -165,6 +194,7 @@ assign ~RESULT = ~SYM[0][~LIT[1]-1 : 0];"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.resize#"
+    , "type"      : "resize# :: KnownNat m => Unsigned n -> Unsigned m"
     , "templateE" : "$unsigned(~ARG[1])"
     }
   }

--- a/clash-systemverilog/primitives/CLaSH.Sized.Vector.json
+++ b/clash-systemverilog/primitives/CLaSH.Sized.Vector.json
@@ -1,15 +1,18 @@
 [ { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.eq#"
+    , "type"      : "eq# :: Eq a => Vec n a -> Vec n a -> Bool"
     , "templateE" : "~ARG[0] == ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.neq#"
+    , "type"      : "neq# :: Eq a => Vec n a -> Vec n a -> Bool"
     , "templateE" : "~ARG[0] != ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.head"
+    , "type"      : "head :: Vec (n + 1) a -> a"
     , "templateD" :
 "// head
 ~SIGD[~SYM[0]][0];
@@ -20,6 +23,7 @@ assign ~RESULT = ~SYM[0][0];"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.tail"
+    , "type"      : "tail :: Vec (n + 1) a -> Vec n a"
     , "templateD" :
 "// tail
 ~SIGD[~SYM[0]][0];
@@ -30,6 +34,7 @@ assign ~RESULT = ~SYM[0][1 : $high(~SYM[0])];"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.last"
+    , "type"      : "Vec (n + 1) a -> a"
     , "templateD" :
 "// last
 ~SIGD[~SYM[0]][0];
@@ -40,6 +45,7 @@ assign ~RESULT = ~SYM[0][$high(~SYM[0])];"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.init"
+    , "type"      : "Vec (n + 1) a -> Vec n a"
     , "templateD" :
 "// init
 ~SIGD[~SYM[0]][0];
@@ -49,14 +55,14 @@ assign ~RESULT = ~SYM[0][0 : $high(~SYM[0]) - 1];"
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Sized.Vector.select"
-    , "comment"   :
-    "select :: (CmpNat (i + s) (s * n) ~ GT) -- ARG[0]
-            => SNat f                        -- ARG[1]
-            -> SNat s                        -- ARG[2]
-            -> SNat n                        -- ARG[3]
-            -> Vec i a                       -- ARG[4]
-            -> Vec n a"
+    { "name" : "CLaSH.Sized.Vector.select"
+    , "type" :
+"select :: (CmpNat (i + s) (s * n) ~ GT) -- ARG[0]
+        => SNat f                        -- ARG[1]
+        -> SNat s                        -- ARG[2]
+        -> SNat n                        -- ARG[3]
+        -> Vec i a                       -- ARG[4]
+        -> Vec n a"
     , "templateD" :
 "// select
 ~SIGD[~SYM[0]][4];
@@ -72,6 +78,7 @@ endgenerate"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.++"
+    , "type"      : "(++) :: Vec n a -> Vec m a -> Vec (n + m) a"
     , "templateD" :
 "// (++)
 ~SIGD[~SYM[0]][0];
@@ -94,6 +101,7 @@ endgenerate"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.concat"
+    , "type"      : "concat :: Vec n (Vec m a) -> Vec (n * m) a"
     , "templateD" :
 "// concat
 ~SIGD[~SYM[0]][0];
@@ -109,6 +117,7 @@ endgenerate"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.splitAt"
+    , "type"      : "splitAt :: SNat m -> Vec (m + n) a -> (Vec m a, Vec n a)"
     , "templateD" :
 "// splitAt
 ~SIGD[~SYM[0]][1];
@@ -120,12 +129,12 @@ assign ~RESULT = '{~SYM[0][$left(~RESULT.~TYPMO_sel0) : $right(~RESULT.~TYPMO_se
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Sized.Vector.unconcat"
-    , "comment"   :
-    "unconcat :: KnownNat n     -- ARG[0]
-              => SNat m         -- ARG[1]
-              -> Vec (n * m) a  -- ARG[2]
-              -> Vec n (Vec m a)"
+    { "name" : "CLaSH.Sized.Vector.unconcat"
+    , "type" :
+ "unconcat :: KnownNat n     -- ARG[0]
+           => SNat m         -- ARG[1]
+           -> Vec (n * m) a  -- ARG[2]
+           -> Vec n (Vec m a)"
     , "templateD" :
 "// unconcat
 ~SIGD[~SYM[0]][2];
@@ -141,6 +150,7 @@ endgenerate"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.merge"
+    , "type"      : "merge :: Vec n a -> Vec n a -> Vec (n + n) a"
     , "templateD" :
 "// merge
 ~SIGD[~SYM[0]][0];
@@ -159,6 +169,7 @@ endgenerate"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.map"
+    , "type"      : "map :: (a -> b) -> Vec n a -> Vec n b"
     , "templateD" :
 "// map
 ~SIGD[~SYM[0]][1];
@@ -177,6 +188,7 @@ endgenerate"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.zipWith"
+    , "type"      : "zipWith :: (a -> b -> c) -> Vec n a -> Vec n b -> Vec n c"
     , "templateD" :
 "// zipWith
 ~SIGD[~SYM[0]][1];
@@ -198,6 +210,7 @@ endgenerate"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.index_integer"
+    , "type"      : "index_integer :: KnownNat n => Vec n a -> Integer -> a"
     , "templateD" :
 "// index_integer
 ~SIGD[~SYM[0]][1];
@@ -223,6 +236,7 @@ end"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.replace_integer"
+    , "type"      : "replace_integer :: KnownNat n => Vec n a -> Integer -> a -> Vec n a"
     , "templateD" :
 "// replace_integer
 ~SIGD[~SYM[0]][2];
@@ -248,21 +262,25 @@ assign ~RESULT = ~SYM[1];"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.maxIndex"
+    , "type"      : "maxIndex :: KnownNat n => Vec n a -> Integer"
     , "templateE" : "~LIT[0] - 1"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.length"
+    , "type"      : "length :: KnownNat n => Vec n a -> Integer"
     , "templateE" : "~LIT[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.replicate"
+    , "type"      : "replicate :: SNat n -> a -> Vec n a"
     , "templateE" : "'{~LIT[0] {~ARG[1]}}"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.reverse"
+    , "type"      : "reverse :: Vec n a -> Vec n a"
     , "templateD" :
 "// reverse
 ~SIGD[~SYM[0]][0];
@@ -278,15 +296,16 @@ endgenerate"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.lazyV"
+    , "type"      : "lazyV :: KnownNat n => Vec n a -> Vec n a"
     , "templateE" : "~ARG[1]"
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Sized.Vector.concatBitVector#"
-    , "comment"   :
-      "concatBitVector# :: KnownNat m           -- ARG[0]
-                        => Vec n (BitVector m)  -- ARG[1]
-                        -> BitVector (n * m)"
+    { "name" : "CLaSH.Sized.Vector.concatBitVector#"
+    , "type" :
+"concatBitVector# :: KnownNat m           -- ARG[0]
+                  => Vec n (BitVector m)  -- ARG[1]
+                  -> BitVector (n * m)"
     , "templateD" :
 "// concatBitVector
 ~SIGD[~SYM[0]][1];
@@ -301,11 +320,11 @@ endgenerate"
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Sized.Vector.unconcatBitVector#"
-    , "comment"   :
-      "unconcatBitVector# :: (KnownNat n, KnownNat m) -- (ARG[0],ARG[1])
-                          => BitVector (n * m)        -- ARG[2]
-                          -> Vec n (BitVector m)"
+    { "name" : "CLaSH.Sized.Vector.unconcatBitVector#"
+    , "type" :
+"unconcatBitVector# :: (KnownNat n, KnownNat m) -- (ARG[0],ARG[1])
+                    => BitVector (n * m)        -- ARG[2]
+                    -> Vec n (BitVector m)"
     , "templateD" :
 "// unconcatBitVector
 ~SIGD[~SYM[0]][2];

--- a/clash-systemverilog/primitives/Control.Exception.Base.json
+++ b/clash-systemverilog/primitives/Control.Exception.Base.json
@@ -1,20 +1,24 @@
 [ { "BlackBox" :
     { "name"      : "Control.Exception.Base.patError"
+    , "type"      : "patError :: Addr# -> a"
     , "templateE" : "~ERRORO"
     }
   }
 , { "BlackBox" :
     { "name"      : "Control.Exception.Base.irrefutPatError"
+    , "type"      : "irrefutPatError :: Addr# -> a"
     , "templateE" : "~ERRORO"
     }
   }
 , { "BlackBox" :
     { "name"      : "Control.Exception.Base.recSelError"
+    , "type"      : "recSelError :: Addr# -> a"
     , "templateE" : "~ERRORO"
     }
   }
 , { "BlackBox" :
     { "name"      : "Control.Exception.Base.absentError"
+    , "type"      : "absentError :: Addr# -> a"
     , "templateE" : "~ERRORO"
     }
   }

--- a/clash-systemverilog/primitives/GHC.Base.json
+++ b/clash-systemverilog/primitives/GHC.Base.json
@@ -5,16 +5,19 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Base.quotInt"
+    , "type"      : "quotInt :: Int -> Int -> Int"
     , "templateE" : "~ARG[0] / ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Base.remInt"
+    , "type"      : "remInt :: Int -> Int -> Int"
     , "templateE" : "~ARG[0] % ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Base.divInt"
+    , "type"      : "divInt :: Int -> Int -> Int"
     , "templateD" :
 "// divInt
 ~SIGD[~SYM[0]][0];
@@ -32,6 +35,7 @@ assign ~RESULT = (~SYM[1][31] == ~SYM[2][31]) ? ~SYM[0] : ~SYM[0] - 32'sd1;"
   }
 , { "BlackBox" :
     { "name"      : "GHC.Base.modInt"
+    , "type"      : "modInt :: Int -> Int -> Int"
     , "templateD" :
 "// modInt
 ~SIGD[~SYM[0]][0];

--- a/clash-systemverilog/primitives/GHC.Classes.json
+++ b/clash-systemverilog/primitives/GHC.Classes.json
@@ -1,50 +1,60 @@
 [ { "BlackBox" :
     { "name"      : "GHC.Classes.eqInt"
+    , "type"      : "eqInt :: Int -> Int -> Bool"
     , "templateE" : "~ARG[0] == ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Classes.neInt"
+    , "type"      : "neInt :: Int -> Int -> Bool"
     , "templateE" : "~ARG[0] != ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Classes.gtInt"
+    , "type"      : "gtInt :: Int -> Int -> Bool"
     , "templateE" : "~ARG[0] > ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Classes.geInt"
+    , "type"      : "geInt :: Int -> Int -> Bool"
     , "templateE" : "~ARG[0] >= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Classes.ltInt"
+    , "type"      : "ltInt :: Int -> Int -> Bool"
     , "templateE" : "~ARG[0] < ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Classes.leInt"
+    , "type"      : "leInt :: Int -> Int -> Bool"
     , "templateE" : "~ARG[0] <= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Classes.&&"
+    , "type"      : "(&&) :: Bool -> Bool -> Bool"
     , "templateE" : "~ARG[0] & ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Classes.||"
+    , "type"      : "(::) :: Bool -> Bool -> Bool"
     , "templateE" : "~ARG[0] | ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Classes.not"
+    , "type"      : "not :: Bool -> Bool"
     , "templateE" : "~ ~ARG[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Classes.divInt#"
+    , "type"      : "divInt# :: Int# -> Int# -> Int#"
     , "templateD" :
 "// divInt
 ~SIGD[~SYM[0]][0];
@@ -62,6 +72,7 @@ assign ~RESULT = (~SYM[1][31] == ~SYM[2][31]) ? ~SYM[0] : ~SYM[0] - 32'sd1;"
   }
 , { "BlackBox" :
     { "name"      : "GHC.Classes.modInt#"
+    , "type"      : "modInt# :: Int# -> Int# -> Int#"
     , "templateD" :
 "// modInt
 ~SIGD[~SYM[0]][0];

--- a/clash-systemverilog/primitives/GHC.Err.json
+++ b/clash-systemverilog/primitives/GHC.Err.json
@@ -1,10 +1,12 @@
 [ { "BlackBox" :
     { "name"      : "GHC.Err.error"
+    , "type"      : "error :: [Char] -> a"
     , "templateE" : "~ERRORO"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Err.undefined"
+    , "type"      : "undefined :: a"
     , "templateE" : "~ERRORO"
     }
   }

--- a/clash-systemverilog/primitives/GHC.Integer.Type.json
+++ b/clash-systemverilog/primitives/GHC.Integer.Type.json
@@ -1,40 +1,48 @@
 [ { "BlackBox" :
     { "name"      : "GHC.Integer.Type.smallInteger"
+    , "type"      : "smallInteger :: Int# -> Integer"
     , "templateE" : "~ARG[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.integerToInt"
+    , "type"      : "integerToInt :: Integer -> Int#"
     , "templateE" : "~ARG[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.plusInteger"
+    , "type"      : "plusInteger :: Integer -> Integer -> Integer"
     , "templateE" : "~ARG[0] + ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.minusInteger"
+    , "type"      : "minusInteger :: Integer -> Integer -> Integer"
     , "templateE" : "~ARG[0] - ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.timesInteger"
+    , "type"      : "timesInteger :: Integer -> Integer -> Integer"
     , "templateE" : "~ARG[0] * ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.negateInteger"
+    , "type"      : "negateInteger :: Integer -> Integer"
     , "templateE" : "-~ARG[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.absInteger"
+    , "type"      : "absInteger :: Integer -> Integer"
     , "templateE" : "~ARG[0] < 32'sd0 ? -~ARG[0] : ~ARG[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.divInteger"
+    , "type"      : "divInteger :: Integer -> Integer -> Integer"
     , "templateD" :
 "// divInteger
 ~SIGD[~SYM[0]][0];
@@ -52,6 +60,7 @@ assign ~RESULT = (~SYM[1][31] == ~SYM[2][31]) ? ~SYM[0] : ~SYM[0] - 32'sd1;"
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.modInteger"
+    , "type"      : "modInteger :: Integer -> Integer -> Integer"
     , "templateD" :
 "// modInteger
 ~SIGD[~SYM[0]][0];
@@ -71,81 +80,97 @@ assign ~RESULT = (~SYM[1][31] == ~SYM[2][31]) ?
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.quotInteger"
+    , "type"      : "quotInteger :: Integer -> Integer -> Integer"
     , "templateE" : "~ARG[0] / ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.remInteger"
+    , "type"      : "remInteger :: Integer -> Integer -> Integer"
     , "templateE" : "~ARG[0] % ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.eqInteger"
+    , "type"      : "eqInteger :: Integer -> Integer -> Bool"
     , "templateE" : "~ARG[0] == ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.neqInteger"
+    , "type"      : "neqInteger :: Integer -> Integer -> Bool"
     , "templateE" : "~ARG[0] != ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.leInteger"
+    , "type"      : "leInteger :: Integer -> Integer -> Bool"
     , "templateE" : "~ARG[0] <= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.gtInteger"
+    , "type"      : "gtInteger :: Integer -> Integer -> Bool"
     , "templateE" : "~ARG[0] > ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.ltInteger"
+    , "type"      : "ltInteger :: Integer -> Integer -> Bool"
     , "templateE" : "~ARG[0] < ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.geInteger"
+    , "type"      : "geInteger :: Integer -> Integer -> Bool"
     , "templateE" : "~ARG[0] >= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.eqInteger#"
+    , "type"      : "eqInteger :: Integer -> Integer -> Bool"
     , "templateE" : "(~ARG[0] == ~ARG[1]) ? 32'sd1 : 32'sd0"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.neqInteger#"
+    , "type"      : "neqInteger :: Integer -> Integer -> Bool"
     , "templateE" : "(~ARG[0] != ~ARG[1]) ? 32'sd1 : 32'sd0"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.leInteger#"
+    , "type"      : "leInteger :: Integer -> Integer -> Bool"
     , "templateE" : "(~ARG[0] <= ~ARG[1]) ? 32'sd1 : 32'sd0"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.gtInteger#"
+    , "type"      : "gtInteger :: Integer -> Integer -> Bool"
     , "templateE" : "(~ARG[0] > ~ARG[1] ? 32'sd1 : 32'sd0"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.ltInteger#"
+    , "type"      : "ltInteger :: Integer -> Integer -> Bool"
     , "templateE" : "(~ARG[0] < ~ARG[1]) ? 32'sd1 : 32'sd0"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.geInteger#"
+    , "type"      : "geInteger :: Integer -> Integer -> Bool"
     , "templateE" : "(~ARG[0] >= ~ARG[1]) ? 32'sd1 : 32'sd0"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.shiftRInteger"
+    , "type"      : "shiftRInteger :: Integer -> Int# -> Integer"
     , "templateE" : "~ARG[0] >>> ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.shiftLInteger"
+    , "type"      : "shiftLInteger :: Integer -> Int# -> Integer"
     , "templateE" : "~ARG[0] <<< ~ARG[1]"
     }
   }

--- a/clash-systemverilog/primitives/GHC.Prim.json
+++ b/clash-systemverilog/primitives/GHC.Prim.json
@@ -1,60 +1,72 @@
 [ { "BlackBox" :
     { "name"      : "GHC.Prim.+#"
+    , "type"      : "(+#) :: Int# -> Int# -> Int#"
     , "templateE" : "~ARG[0] + ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.-#"
+    , "type"      : "(-#) :: Int# -> Int# -> Int#"
     , "templateE" : "~ARG[0] - ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.*#"
+    , "type"      : "(*#) :: Int# -> Int# -> Int#"
     , "templateE" : "~ARG[0] * ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.quotInt#"
+    , "type"      : "quotInt# :: Int# -> Int# -> Int#"
     , "templateE" : "~ARG[0] / ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.remInt#"
+    , "type"      : "remInt# :: Int# -> Int# -> Int#"
     , "templateE" : "~ARG[0] % ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.negateInt#"
+    , "type"      : "negateInt# :: Int# -> Int#"
     , "templateE" : "-~ARG[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.>#"
+     , "type"      : "(>#) :: Int# -> Int# -> Bool"
     , "templateE" : "(~ARG[0] > ~ARG[1]) ? 32'sd1 : 32'sd0"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.>=#"
+    , "type"      : "(>=#) :: Int# -> Int# -> Bool"
     , "templateE" : "(~ARG[0] >= ~ARG[1]) ? 32'sd1 : 32'sd0"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.==#"
+    , "type"      : "(==) :: Int# -> Int# -> Bool"
     , "templateE" : "(~ARG[0] == ~ARG[1]) ? 32'sd1 : 32'sd0"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim./=#"
+    , "type"      : "(/=#) :: Int# -> Int# -> Bool"
     , "templateE" : "(~ARG[0] != ~ARG[1]) ? 32'sd1 : 32'sd0"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.<#"
+    , "type"      : "(<#) :: Int# -> Int# -> Bool"
     , "templateE" : "(~ARG[0] < ~ARG[1]) ? 32'sd1 : 32'sd0"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.<=#"
+    , "type"      : "(<=#) :: Int# -> Int# -> Bool"
     , "templateE" : "(~ARG[0] <= ~ARG[1]) ? 32'sd1 : 32'sd0"
     }
   }
@@ -70,6 +82,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.unsafeCoerce#"
+    , "type"      : "unsafeCoerce# :: a -> b"
     , "templateE" : "~ARG[0]"
     }
   }

--- a/clash-systemverilog/primitives/GHC.Real.json
+++ b/clash-systemverilog/primitives/GHC.Real.json
@@ -1,15 +1,18 @@
 [ { "BlackBox" :
     { "name"      : "GHC.Real.divZeroError"
+    , "type"      : "divZeroError :: a"
     , "templateE" : "~ERRORO"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Real.ratioZeroDenominatorError"
+    , "type"      : "ratioZeroDenominatorError :: a"
     , "templateE" : "~ERRORO"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Real.overflowError"
+    , "type"      : "overflowError :: a"
     , "templateE" : "~ERRORO"
     }
   }

--- a/clash-systemverilog/primitives/GHC.Typelits.json
+++ b/clash-systemverilog/primitives/GHC.Typelits.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "GHC.TypeLits.natVal"
+    , "type"      : "natVal :: forall n proxy. KnownNat n => proxy n -> Integer"
     , "templateE" : "~LIT[0]"
     }
   }

--- a/clash-systemverilog/primitives/Unsafe.Coerce.json
+++ b/clash-systemverilog/primitives/Unsafe.Coerce.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Unsafe.Coerce.unsafeCoerce"
+    , "type"      : "unsafeCoerce :: a -> b"
     , "templateE" : "~ARG[0]"
     }
   }

--- a/clash-systemverilog/src/CLaSH/Backend/SystemVerilog.hs
+++ b/clash-systemverilog/src/CLaSH/Backend/SystemVerilog.hs
@@ -238,11 +238,10 @@ decls ds = do
     dsDoc <- catMaybes A.<$> mapM decl ds
     case dsDoc of
       [] -> empty
-      _  -> vcat (A.pure dsDoc)
+      _  -> punctuate' semi (A.pure dsDoc)
 
 decl :: Declaration -> SystemVerilogM (Maybe Doc)
-decl (NetDecl id_ ty netInit) = Just A.<$> sigDecl (text id_) ty <> semi <$>
-  maybe empty (\e -> "// pragma translate_off" <$> "initial begin" <$> indent 2 (text id_ <+> "=" <+> expr_ False e <> semi) <$> "end" <$> "// pragma translate_on") netInit
+decl (NetDecl id_ ty) = Just A.<$> sigDecl (text id_) ty
 
 decl _ = return Nothing
 
@@ -277,7 +276,7 @@ inst_ (BlackBoxD _ bs bbCtx) = do
   t <- renderBlackBox bs bbCtx
   fmap Just (string t)
 
-inst_ (NetDecl _ _ _) = return Nothing
+inst_ (NetDecl _ _) = return Nothing
 
 -- | Turn a Netlist expression into a SystemVerilog expression
 expr_ :: Bool -- ^ Enclose in parenthesis?
@@ -454,3 +453,6 @@ listBraces = encloseSep lbrace rbrace comma
 parenIf :: Monad m => Bool -> m Doc -> m Doc
 parenIf True  = parens
 parenIf False = id
+
+punctuate' :: Monad m => m Doc -> m [Doc] -> m Doc
+punctuate' s d = vcat (punctuate s d) <> s

--- a/clash-systemverilog/src/CLaSH/Backend/SystemVerilog.hs
+++ b/clash-systemverilog/src/CLaSH/Backend/SystemVerilog.hs
@@ -23,7 +23,7 @@ import           Data.Text.Lazy                       (unpack)
 import           Text.PrettyPrint.Leijen.Text.Monadic
 
 import           CLaSH.Backend
-import           CLaSH.Netlist.BlackBox.Util          (parseFail, renderBlackBox)
+import           CLaSH.Netlist.BlackBox.Util          (extractLiterals, parseFail, renderBlackBox)
 import           CLaSH.Netlist.Types
 import           CLaSH.Netlist.Util
 import           CLaSH.Util                           (curLoc, makeCached, (<:>))
@@ -275,7 +275,7 @@ inst_ (InstDecl nm lbl pms) = fmap Just $
 
 inst_ (BlackBoxD pNm _ bbCtx)
   | pNm == "CLaSH.Sized.Internal.Signed.resize#"
-  , ((Literal _ (NumLit n)):(Literal _ (NumLit m)):_) <- bbLitInputs bbCtx
+  , ((Literal _ (NumLit n)):(Literal _ (NumLit m)):_) <- extractLiterals bbCtx
   , n < m
   = do
     let bs = parseFail "assign ~RESULT = $signed(~ARG[2]);"
@@ -333,17 +333,17 @@ expr_ _ (DataCon ty@(Product _ _) _ es) = "'" <> listBraces (zipWithM (\i e -> v
 
 expr_ _ (BlackBoxE pNm _ bbCtx _)
   | pNm == "CLaSH.Sized.Internal.Signed.fromInteger#"
-  , [Literal _ (NumLit n), Literal _ i] <- bbLitInputs bbCtx
+  , [Literal _ (NumLit n), Literal _ i] <- extractLiterals bbCtx
   = exprLit (Just (Signed (fromInteger n),fromInteger n)) i
 
 expr_ _ (BlackBoxE pNm _ bbCtx _)
   | pNm == "CLaSH.Sized.Internal.Unsigned.fromInteger#"
-  , [Literal _ (NumLit n), Literal _ i] <- bbLitInputs bbCtx
+  , [Literal _ (NumLit n), Literal _ i] <- extractLiterals bbCtx
   = exprLit (Just (Unsigned (fromInteger n),fromInteger n)) i
 
 expr_ _ (BlackBoxE pNm _ bbCtx _)
   | pNm == "CLaSH.Sized.Internal.BitVector.fromInteger#"
-  , [Literal _ (NumLit n), Literal _ i] <- bbLitInputs bbCtx
+  , [Literal _ (NumLit n), Literal _ i] <- extractLiterals bbCtx
   = exprLit (Just (BitVector (fromInteger n),fromInteger n)) i
 
 expr_ b (BlackBoxE _ bs bbCtx b') = do

--- a/clash-systemverilog/src/CLaSH/Backend/SystemVerilog.hs
+++ b/clash-systemverilog/src/CLaSH/Backend/SystemVerilog.hs
@@ -23,7 +23,7 @@ import           Data.Text.Lazy                       (unpack)
 import           Text.PrettyPrint.Leijen.Text.Monadic
 
 import           CLaSH.Backend
-import           CLaSH.Netlist.BlackBox.Util          (extractLiterals, parseFail, renderBlackBox)
+import           CLaSH.Netlist.BlackBox.Util          (extractLiterals, renderBlackBox)
 import           CLaSH.Netlist.Types
 import           CLaSH.Netlist.Util
 import           CLaSH.Util                           (curLoc, makeCached, (<:>))
@@ -272,15 +272,6 @@ inst_ (InstDecl nm lbl pms) = fmap Just $
     text nm <+> text lbl <$$> pms' <> semi
   where
     pms' = tupled $ sequence [dot <> text i <+> parens (expr_ False e) | (i,e) <- pms]
-
-inst_ (BlackBoxD pNm _ bbCtx)
-  | pNm == "CLaSH.Sized.Internal.Signed.resize#"
-  , ((Literal _ (NumLit n)):(Literal _ (NumLit m)):_) <- extractLiterals bbCtx
-  , n < m
-  = do
-    let bs = parseFail "assign ~RESULT = $signed(~ARG[2]);"
-    t <- renderBlackBox bs bbCtx
-    fmap Just (string t)
 
 inst_ (BlackBoxD _ bs bbCtx) = do
   t <- renderBlackBox bs bbCtx

--- a/clash-vhdl/primitives/CLaSH.Driver.TestbenchGen.json
+++ b/clash-vhdl/primitives/CLaSH.Driver.TestbenchGen.json
@@ -4,6 +4,7 @@
 "-- pragma translate_off
 process is
 begin
+  ~RESULT <= '0';
   wait for ~LIT[0] ns;
   while (not finished) loop
     ~RESULT <= not ~RESULT;
@@ -20,7 +21,7 @@ end process;
     { "name"      : "CLaSH.Driver.TestbenchGen.resetGen"
     , "templateD" :
 "-- pragma translate_off
-~RESULT <= '0' after 0 ns,
+~RESULT <= '0',
            '1' after ~LIT[0] ns;
 -- pragma translate_on"
     }
@@ -33,9 +34,13 @@ end process;
 , { "BlackBox" :
     { "name"      : "CLaSH.Driver.TestbenchGen.finishedGen"
     , "templateD" :
-"~RESULT <= ~LIT[0]
+"~RESULT <=
 -- pragma translate_off
-            after ~LIT[1] ns
+            false,
+-- pragma translate_on
+            true
+-- pragma translate_off
+            after ~LIT[0] ns
 -- pragma translate_on
             ;"
     }

--- a/clash-vhdl/primitives/CLaSH.Prelude.BlockRam.json
+++ b/clash-vhdl/primitives/CLaSH.Prelude.BlockRam.json
@@ -1,14 +1,14 @@
 [ { "BlackBox" :
-    { "name"      : "CLaSH.Prelude.BlockRam.cblockRam"
-    , "comment"   :
-    "cblockRam :: (KnownNat n, KnownNat m) -- (ARG[0],ARG[1])
-          => SClock clk                    -- clk,  ARG[2]
-          -> Vec n a                       -- init, ARG[3]
-          -> CSignal clk (Unsigned m)      -- wr,   ARG[4]
-          -> CSignal clk (Unsigned m)      -- rd,   ARG[5]
-          -> CSignal clk Bool              -- wren, ARG[6]
-          -> CSignal clk a                 -- din,  ARG[7]
-          -> CSignal clk a"
+    { "name" : "CLaSH.Prelude.BlockRam.cblockRam"
+    , "type" :
+"cblockRam :: (KnownNat n, KnownNat m) -- (ARG[0],ARG[1])
+           => SClock clk               -- clk,  ARG[2]
+           -> Vec n a                  -- init, ARG[3]
+           -> CSignal clk (Unsigned m) -- wr,   ARG[4]
+           -> CSignal clk (Unsigned m) -- rd,   ARG[5]
+           -> CSignal clk Bool         -- wren, ARG[6]
+           -> CSignal clk a            -- din,  ARG[7]
+           -> CSignal clk a"
     , "templateD" :
 "blockram_~SYM[0] : block
   signal ~SYM[1] : ~TYP[3] := ~LIT[3]; -- ram

--- a/clash-vhdl/primitives/CLaSH.Prelude.Testbench.json
+++ b/clash-vhdl/primitives/CLaSH.Prelude.Testbench.json
@@ -1,11 +1,11 @@
 [ { "BlackBox" :
-    { "name"      : "CLaSH.Prelude.Testbench.csassert"
-    , "comment"   :
-    "csassert :: (Eq a,Show a) -- (ARG[0],ARG[1])
-         => CSignal t a -- ^ Checked value (ARG[2])
-         -> CSignal t a -- ^ Expected value (ARG[3])
-         -> CSignal t b -- ^ Return valued (ARG[4])
-         -> CSignal t b"
+    { "name" : "CLaSH.Prelude.Testbench.csassert"
+    , "type" :
+"csassert :: (Eq a,Show a) -- (ARG[0],ARG[1])
+          => CSignal t a   -- ^ Checked value (ARG[2])
+          -> CSignal t a   -- ^ Expected value (ARG[3])
+          -> CSignal t b   -- ^ Return valued (ARG[4])
+          -> CSignal t b"
     , "templateD" :
 "assert_~SYM[0] : block
 begin

--- a/clash-vhdl/primitives/CLaSH.Prelude.Testbench.json
+++ b/clash-vhdl/primitives/CLaSH.Prelude.Testbench.json
@@ -8,6 +8,7 @@
           -> CSignal t b"
     , "templateD" :
 "assert_~SYM[0] : block
+  -- pragma translate_off
   function slv2string (slv : std_logic_vector) return STRING is
      variable result : string (1 to slv'length);
      variable r : integer;
@@ -19,6 +20,7 @@
      end loop;
      return result;
   end;
+  -- pragma translate_on
 begin
   -- pragma translate_off
   process(~CLK[2],~RST[2],~ARG[2],~ARG[3]) is

--- a/clash-vhdl/primitives/CLaSH.Prelude.Testbench.json
+++ b/clash-vhdl/primitives/CLaSH.Prelude.Testbench.json
@@ -8,12 +8,23 @@
           -> CSignal t b"
     , "templateD" :
 "assert_~SYM[0] : block
+  function slv2string (slv : std_logic_vector) return STRING is
+     variable result : string (1 to slv'length);
+     variable r : integer;
+   begin
+     r := 1;
+     for i in slv'range loop
+        result(r) := std_logic'image(slv(i))(2);
+        r := r + 1;
+     end loop;
+     return result;
+  end;
 begin
   -- pragma translate_off
   process(~CLK[2],~RST[2],~ARG[2],~ARG[3]) is
   begin
     if (rising_edge(~CLK[2]) or rising_edge(~RST[2])) then
-      assert (~ARG[2] = ~ARG[3]) report (\"expected: \" & to_string (~ARG[3]) & \", actual: \" & to_string (~ARG[2])) severity error;
+      assert (~ARG[2] = ~ARG[3]) report (\"expected: \" & slv2string(toSLV(~ARG[3])) & \", actual: \" & slv2string(toSLV(~ARG[2]))) severity error;
     end if;
   end process;
   -- pragma translate_on

--- a/clash-vhdl/primitives/CLaSH.Promoted.Nat.json
+++ b/clash-vhdl/primitives/CLaSH.Promoted.Nat.json
@@ -1,10 +1,12 @@
 [ { "BlackBox" :
     { "name"      : "CLaSH.Promoted.Nat.SNat"
+    , "type"      : "SNat :: KnownNat n => Proxy n -> SNat n"
     , "templateE" : "~LIT[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Promoted.Nat.snatToInteger"
+    , "type"      : "snatToInteger :: SNat n -> Integer"
     , "templateE" : "~LIT[0]"
     }
   }

--- a/clash-vhdl/primitives/CLaSH.Promoted.Symbol.json
+++ b/clash-vhdl/primitives/CLaSH.Promoted.Symbol.json
@@ -1,10 +1,12 @@
 [ { "BlackBox" :
     { "name"      : "CLaSH.Promoted.Symbol.SSymbol"
+    , "type"      : "SSymbol :: KnownNat n => Proxy n -> SSymbol n"
     , "templateE" : "~LIT[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Promoted.Symbol.symbolToString"
+    , "type"      : "symbolToString :: SSymbol n -> String"
     , "templateE" : "~LIT[0]"
     }
   }

--- a/clash-vhdl/primitives/CLaSH.Signal.Explicit.json
+++ b/clash-vhdl/primitives/CLaSH.Signal.Explicit.json
@@ -1,5 +1,10 @@
 [ { "BlackBox" :
     { "name"      : "CLaSH.Signal.Explicit.veryUnsafeSynchronizer"
+    , "type" :
+"veryUnsafeSynchronizer :: SClock clk1
+                        -> SClock clk2
+                        -> CSignal clk1 a -- ARG[2]
+                        -> CSignal clk2 a"
     , "templateE" : "~ARG[2]"
     }
   }

--- a/clash-vhdl/primitives/CLaSH.Signal.Internal.json
+++ b/clash-vhdl/primitives/CLaSH.Signal.Internal.json
@@ -1,10 +1,10 @@
 [ { "BlackBox" :
-    { "name"      : "CLaSH.Signal.Internal.register#"
-    , "comment"   :
-    "register# :: SClock clk     -- ARG[0]
-               -> a              -- ARG[1]
-               -> CSignal clk a  -- ARG[2]
-               -> CSignal clk a"
+    { "name" : "CLaSH.Signal.Internal.register#"
+    , "type" :
+"register# :: SClock clk     -- ARG[0]
+           -> a              -- ARG[1]
+           -> CSignal clk a  -- ARG[2]
+           -> CSignal clk a"
     , "templateD" :
 "register_~SYM[0] : block
   signal ~SYM[1] : ~TYP[1];
@@ -26,13 +26,13 @@ end block;"
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Signal.Internal.regEn#"
-    , "comment"   :
-    "regEn# :: SClock clk       -- ARG[0]
-            -> a                -- ARG[1]
-            -> CSignal clk Bool -- ARG[2]
-            -> CSignal clk a    -- ARG[3]
-            -> CSignal clk a"
+    { "name" : "CLaSH.Signal.Internal.regEn#"
+    , "type" :
+"regEn# :: SClock clk       -- ARG[0]
+        -> a                -- ARG[1]
+        -> CSignal clk Bool -- ARG[2]
+        -> CSignal clk a    -- ARG[3]
+        -> CSignal clk a"
     , "templateD" :
 "regEn_~SYM[0] : block
   signal ~SYM[1] : ~TYP[1];

--- a/clash-vhdl/primitives/CLaSH.Sized.Internal.BitVector.json
+++ b/clash-vhdl/primitives/CLaSH.Sized.Internal.BitVector.json
@@ -1,31 +1,37 @@
 [ { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.size#"
+    , "type"      : "size# :: KnownNat n => BitVector n -> Int"
     , "templateE" : "~LIT[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.maxIndex#"
+    , "type"      : "maxIndex# :: KnownNat n => BitVector n -> Int"
     , "templateE" : "~LIT[0] - 1"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.high"
+    , "type"      : "high :: Bit"
     , "templateE" : "\"1\""
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.low"
+    , "type"      : "low :: Bit"
     , "templateE" : "\"0\""
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.++#"
+    , "type"      : "(++#) :: KnownNat m => BitVector n -> BitVector m -> BitVector (n + m)"
     , "templateE" : "std_logic_vector'(~ARG[1]) & std_logic_vector'(~ARG[2])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.reduceAnd#"
-    , "templateD"  :
+    , "type"      : "reduceAnd# :: KnownNat n => BitVector n -> BitVector 1"
+    , "templateD" :
 "reduceAnd_~SYM[0] : block
   function and_reduce (arg : std_logic_vector) return std_logic is
     variable upper, lower : std_logic;
@@ -55,7 +61,8 @@ end block;"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.reduceOr#"
-    , "templateD"  :
+    , "type"      : "reduceOr# :: BitVector n -> BitVector 1"
+    , "templateD" :
 "reduceOr_~SYM[0] : block
   function or_reduce (arg : std_logic_vector) return std_logic is
     variable upper, lower : std_logic;
@@ -85,7 +92,8 @@ end block;"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.reduceXor#"
-    , "templateD"  :
+    , "type"      : "reduceXor# :: BitVector n -> BitVector 1"
+    , "templateD" :
 "reduceXor_~SYM[0] : block
   function xor_reduce (arg : std_logic_vector) return std_logic is
     variable upper, lower : std_logic;
@@ -114,12 +122,12 @@ end block;"
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Sized.Internal.BitVector.index#"
-    , "comment"   :
-    "index# :: KnownNat n  -- ARG[0]
-            => BitVector n -- ARG[1]
-            -> Int         -- ARG[2]
-            -> Bit"
+    { "name" : "CLaSH.Sized.Internal.BitVector.index#"
+    , "type" :
+"index# :: KnownNat n  -- ARG[0]
+        => BitVector n -- ARG[1]
+        -> Int         -- ARG[2]
+        -> Bit"
     , "templateD" :
 "indexBit_~SYM[0] : block
   signal ~SYM[1] : ~TYP[1];
@@ -144,13 +152,13 @@ end block;"
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Sized.Internal.BitVector.replaceBit#"
-    , "comment"   :
-    "replaceBit# :: KnownNat n  -- ARG[0]
-                 => BitVector n -- ARG[1]
-                 -> Int         -- ARG[2]
-                 -> Bit         -- ARG[3]
-                 -> BitVector n"
+    { "name" : "CLaSH.Sized.Internal.BitVector.replaceBit#"
+    , "type" :
+"replaceBit# :: KnownNat n  -- ARG[0]
+             => BitVector n -- ARG[1]
+             -> Int         -- ARG[2]
+             -> Bit         -- ARG[3]
+             -> BitVector n"
     , "templateD" :
 "replaceBit_~SYM[0] : block
   signal ~SYM[1] : ~TYP[1];
@@ -180,13 +188,13 @@ end block;"
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Sized.Internal.BitVector.setSlice#"
-    , "comment"   :
-    "setSlice# :: BitVector (m + 1 + i) -- ARG[0]
-               -> SNat m                -- ARG[1]
-               -> SNat n                -- ARG[2]
-               -> BitVector (m + 1 - n) -- ARG[3]
-               -> BitVector (m + 1 + i)"
+    { "name" : "CLaSH.Sized.Internal.BitVector.setSlice#"
+    , "type" :
+"setSlice# :: BitVector (m + 1 + i) -- ARG[0]
+           -> SNat m                -- ARG[1]
+           -> SNat n                -- ARG[2]
+           -> BitVector (m + 1 - n) -- ARG[3]
+           -> BitVector (m + 1 + i)"
     , "templateD" :
 "setSlice_~SYM[0] : block
   signal ~SYM[1] : ~TYP[0];
@@ -205,12 +213,12 @@ end block;"
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Sized.Internal.BitVector.slice#"
-    , "comment"   :
-    "slice# :: BitVector (m + 1 + i) -- ARG[0]
-            -> SNat m                -- ARG[1]
-            -> SNat n                -- ARG[2]
-            -> BitVector (m + 1 - n)"
+    { "name" : "CLaSH.Sized.Internal.BitVector.slice#"
+    , "type" :
+"slice# :: BitVector (m + 1 + i) -- ARG[0]
+        -> SNat m                -- ARG[1]
+        -> SNat n                -- ARG[2]
+        -> BitVector (m + 1 - n)"
     , "templateD" :
 "slice_~SYM[0] : block
   signal ~SYM[1] : ~TYP[0];
@@ -221,11 +229,11 @@ end block;"
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Sized.Internal.BitVector.split#"
-    , "comment"   :
-    "split# :: KnownNat n        -- ARG[0]
-            => BitVector (m + n) -- ARG[1]
-            -> (BitVector m, BitVector n)"
+    { "name" : "CLaSH.Sized.Internal.BitVector.split#"
+    , "type" :
+"split# :: KnownNat n        -- ARG[0]
+        => BitVector (m + n) -- ARG[1]
+        -> (BitVector m, BitVector n)"
     , "templateD" :
 "split_~SYM[0]: block
   signal ~SYM[1] : ~TYP[1];
@@ -239,11 +247,11 @@ end block;"
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Sized.Internal.BitVector.msb#"
-    , "comment"   :
-    "msb# :: KnownNat n  -- ARG[0]
-          => BitVector n -- ARG[1]
-          -> Bit"
+    { "name" : "CLaSH.Sized.Internal.BitVector.msb#"
+    , "type" :
+"msb# :: KnownNat n  -- ARG[0]
+      => BitVector n -- ARG[1]
+      -> Bit"
     , "templateD" :
 "msb_~SYM[0] : block
   signal ~SYM[1] : ~TYP[1];
@@ -261,10 +269,10 @@ end block;"
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Sized.Internal.BitVector.lsb#"
-    , "comment"   :
-    "lsb# :: BitVector n -- ARG[0]
-          -> Bit"
+    { "name" : "CLaSH.Sized.Internal.BitVector.lsb#"
+    , "type" :
+"lsb# :: BitVector n -- ARG[0]
+      -> Bit"
     , "templateD" :
 "lsb_~SYM[0] : block
   signal ~SYM[1] : ~TYP[0];
@@ -284,148 +292,177 @@ end block;"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.eq#"
+    , "type"      : "eq# :: BitVector n -> BitVector n -> Bool"
     , "templateE" : "~ARG[0] = ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.neq#"
+    , "type"      : "neq# :: BitVector n -> BitVector n -> Bool"
     , "templateE" : "~ARG[0] /= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.lt#"
+    , "type"      : "lt# :: BitVector n -> BitVector n -> Bool"
     , "templateE" : "~ARG[0] < ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.ge#"
+    , "type"      : "ge# :: BitVector n -> BitVector n -> Bool"
     , "templateE" : "~ARG[0] >= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.gt#"
+    , "type"      : "gt# :: BitVector n -> BitVector n -> Bool"
     , "templateE" : "~ARG[0] > ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.le#"
+    , "type"      : "le# :: BitVector n -> BitVector n -> Bool"
     , "templateE" : "~ARG[0] <= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.minBound#"
+    , "type"      : "minBound# :: KnownNat n => BitVector n"
     , "comment"   : "Generates incorrect VDHL for n=0"
     , "templateE" : "std_logic_vector'(~LIT[0]-1 downto 0 => '0');"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.maxBound#"
+    , "type"      : "maxBound# :: KnownNat n => BitVector n"
     , "comment"   : "Generates incorrect VDHL for n=0"
     , "templateE" : "std_logic_vector'(~LIT[0]-1 downto 0 => '1');"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.+#"
+    , "type"      : "(+#) :: KnownNat n => BitVector n -> BitVector n -> BitVector n"
     , "templateE" : "std_logic_vector(unsigned(~ARG[1]) + unsigned(~ARG[2]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.-#"
+    , "type"      : "(-#) :: KnownNat n => BitVector n -> BitVector n -> BitVector n"
     , "templateE" : "std_logic_vector(unsigned(~ARG[1]) - unsigned(~ARG[2]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.*#"
+    , "type"      : "(*#) :: KnownNat n => BitVector n -> BitVector n -> BitVector n"
     , "templateE" : "std_logic_vector(resize(unsigned(~ARG[1]) * unsigned(~ARG[2]), ~LIT[0]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.negate#"
+    , "type"      : "negate# :: KnownNat n => BitVector n -> BitVector n"
     , "templateE" : "std_logic_vector(-(signed(~ARG[1])))"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.fromInteger#"
+    , "type"      : "fromInteger# :: KnownNat n => Integer -> BitVector n"
     , "templateE" : "std_logic_vector(to_unsigned(~ARG[1],~LIT[0]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.plus#"
+    , "type"      : "plus# :: KnownNat (Max m n + 1) => BitVector m -> BitVector n -> BitVector (Max m n + 1)"
     , "templateE" : "std_logic_vector(resize(unsigned(~ARG[1]),~LIT[0]) + resize(unsigned(~ARG[2]),~LIT[0]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.minus#"
+    , "type"      : "minus# :: KnownNat (Max m n + 1) => BitVector m -> BitVector n -> BitVector (Max m n + 1)"
     , "templateE" : "std_logic_vector(resize(unsigned(~ARG[1]),~LIT[0]) - resize(unsigned(~ARG[2]),~LIT[0]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.times#"
+    , "type"      : "times# :: KnownNat (m + n) => BitVector m -> BitVector n -> BitVector (m + n)"
     , "templateE" : "std_logic_vector(unsigned(~ARG[1]) * unsigned(~ARG[2]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.quot#"
+    , "type"      : "quot# :: BitVector n -> BitVector n -> BitVector n"
     , "templateE" : "std_logic_vector(unsigned(~ARG[1]) / unsigned(~ARG[2]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.rem#"
+    , "type"      : "rem# :: BitVector n -> BitVector n -> BitVector n"
     , "templateE" : "~ARG[1] rem ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.mod#"
+    , "type"      : "mod# :: BitVector n -> BitVector n -> BitVector n"
     , "templateE" : "~ARG[1] mod ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.toInteger#"
+    , "type"      : "toInteger# :: BitVector n -> Integer"
     , "templateE" : "to_integer(unsigned(~ARG[0]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.and#"
+    , "type"      : "and# :: BitVector n -> BitVector n -> BitVector n"
     , "templateE" : "~ARG[0] and ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.or#"
+    , "type"      : "or# :: BitVector n -> BitVector n -> BitVector n"
     , "templateE" : "~ARG[0] or ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.xor#"
+    , "type"      : "xor# :: BitVector n -> BitVector n -> BitVector n"
     , "templateE" : "~ARG[0] xor ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.complement#"
+    , "type"      : "complement# :: KnownNat n => BitVector n -> BitVector n"
     , "templateE" : "not ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.shiftL#"
+    , "type"      : "shiftL# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "templateE" : "std_logic_vector(shift_left(unsigned(~ARG[1]),~ARG[2]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.shiftR#"
+    , "type"      : "shiftR# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "templateE" : "std_logic_vector(shift_right(unsigned(~ARG[1]),~ARG[2]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.rotateL#"
+    , "type"      : "rotateL# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "templateE" : "std_logic_vector(rotate_left(unsigned(~ARG[1]),~ARG[2]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.rotateR#"
+    , "type"      : "rotateR# :: KnownNat n => BitVector n -> Int -> BitVector n"
     , "templateE" : "std_logic_vector(rotate_right(unsigned(~ARG[1]),~ARG[2]))"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.BitVector.resize#"
+    , "type"      : "resize# :: KnownNat m => BitVector n -> BitVector m"
     , "templateE" : "std_logic_vector(resize(unsigned(~ARG[1]),~LIT[0]))"
     }
   }

--- a/clash-vhdl/primitives/CLaSH.Sized.Internal.Index.json
+++ b/clash-vhdl/primitives/CLaSH.Sized.Internal.Index.json
@@ -1,75 +1,90 @@
 [ { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.eq#"
+    , "type"      : "eq# :: Index n -> Index n -> Bool"
     , "templateE" : "~ARG[0] = ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.neq#"
+    , "type"      : "neq# :: Index n -> Index n -> Bool"
     , "templateE" : "~ARG[0] /= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.lt#"
+    , "type"      : "lt# :: Index n -> Index n -> Bool"
     , "templateE" : "~ARG[0] < ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.ge#"
+    , "type"      : "ge# :: Index n -> Index n -> Bool"
     , "templateE" : "~ARG[0] >= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.gt#"
+    , "type"      : "gt# :: Index n -> Index n -> Bool"
     , "templateE" : "~ARG[0] > ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.le#"
+    , "type"      : "le# :: Index n -> Index n -> Bool"
     , "templateE" : "~ARG[0] <= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.maxBound#"
+    , "type"      : "maxBound# :: KnownNat n => Index n"
     , "templateE" : "to_unsigned(max(0,~LIT[0]-1),~RESULT'length);"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.+#"
+    , "type"      : "(+#) :: KnownNat n => Index n -> Index n -> Index n"
     , "templateE" : "~ARG[1] + ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.-#"
+    , "type"      : "(-#) :: KnownNat n => Index n -> Index n -> Index n"
     , "templateE" : "~ARG[1] - ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.*#"
+    , "type"      : "(*#) :: KnownNat n => Index n -> Index n -> Index n"
     , "templateE" : "resize(~ARG[1] * ~ARG[2], ~LIT[0])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.fromInteger#"
+    , "type"      : "fromInteger# :: KnownNat n => Integer -> Index n"
     , "templateE" : "to_unsigned(~ARG[1],integer(ceil(log2(real(max(2,~LIT[0]))))))"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.quot#"
+    , "type"      : "quot# :: KnownNat n => Index n -> Index n -> Index n"
     , "templateE" : "~ARG[1] / ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.rem#"
+    , "type"      : "rem# :: KnownNat n => Index n -> Index n -> Index n"
     , "templateE" : "~ARG[1] rem ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.mod#"
+    , "type"      : "mod# :: KnownNat n => Index n -> Index n -> Index n"
     , "templateE" : "~ARG[1] mod ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Index.toInteger#"
+    , "type"      : "toInteger# :: Index n -> Integer"
     , "templateE" : "to_integer(~ARG[0])"
     }
   }

--- a/clash-vhdl/primitives/CLaSH.Sized.Internal.Signed.json
+++ b/clash-vhdl/primitives/CLaSH.Sized.Internal.Signed.json
@@ -1,50 +1,60 @@
 [ { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Internal.Signed.size#"
+    , "type"      : "size# :: KnownNat n => Signed n -> Int"
     , "templateE" : "~LIT[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.pack#"
+    , "type"      : "pack# :: KnownNat n => Signed n -> BitVector n"
     , "templateE" : "std_logic_vector(~ARG[1])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.unpack#"
+    , "type"      : "unpack# :: KnownNat n => BitVector n -> Signed n"
     , "templateE" : "signed(~ARG[1])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.eq#"
+    , "type"      : "eq# :: Signed n -> Signed n -> Bool"
     , "templateE" : "~ARG[0] = ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.neq#"
+    , "type"      : "neq# :: Signed n -> Signed n -> Bool"
     , "templateE" : "~ARG[0] /= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.lt#"
+    , "type"      : "lt# :: Signed n -> Signed n -> Bool"
     , "templateE" : "~ARG[0] < ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.ge#"
+    , "type"      : "ge# :: Signed n -> Signed n -> Bool"
     , "templateE" : "~ARG[0] >= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.gt#"
+    , "type"      : "gt# :: Signed n -> Signed n -> Bool"
     , "templateE" : "~ARG[0] > ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.le#"
+    , "type"      : "le# :: Signed n -> Signed n -> Bool"
     , "templateE" : "~ARG[0] <= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.minBound#"
+    , "type"      : "minBound# :: KnownNat n => Signed n"
     , "comment"   : "Generates incorrect VDHL for n=0"
     , "comment2"  : "the quantification with signed gives the array an ascending index"
     , "templateE" : "signed'(0 => '1', 1 to ~LIT[0]-1 => '0')"
@@ -52,6 +62,7 @@
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.maxBound#"
+    , "type"      : "maxBound# :: KnownNat n => Signed n"
     , "comment"   : "Generates incorrect VDHL for n=0"
     , "comment2"  : "the quantification with signed gives the array an ascending index"
     , "templateE" : "signed'(0 => '0', 1 to ~LIT[0]-1  => '1')"
@@ -59,61 +70,73 @@
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.+#"
+    , "type"      : "(+#) :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "templateE" : "~ARG[1] + ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.-#"
+    , "type"      : "(-#) :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "templateE" : "~ARG[1] - ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.*#"
+    , "type"      : "(*#) :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "templateE" : "resize(~ARG[1] * ~ARG[2], ~LIT[0])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.negate#"
+    , "type"      : "negate# :: KnownNat n => Signed n -> Signed n"
     , "templateE" : "-~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.abs#"
+    , "type"      : "abs# :: KnownNat n => Signed n -> Signed n"
     , "templateE" : "abs ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.fromInteger#"
+    , "type"      : "fromInteger# :: KnownNat n => Integer -> Signed (n :: Nat)"
     , "templateE" : "to_signed(~ARG[1],~LIT[0])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.plus#"
+    , "type"      : "plus# :: KnownNat (1 + Max m n) => Signed m -> Signed n -> Signed (1 + Max m n)"
     , "templateE" : "resize(~ARG[1],~LIT[0]) + resize(~ARG[2],~LIT[0])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.minus#"
+    , "type"      : "minus# :: KnownNat (1 + Max m n) => Signed m -> Signed n -> Signed (1 + Max m n)"
     , "templateE" : "resize(~ARG[1],~LIT[0]) - resize(~ARG[2],~LIT[0])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.times#"
+    , "type"      : "times# :: KnownNat (m + n) => Signed m -> Signed n -> Signed (m + n)"
     , "templateE" : "~ARG[1] * ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.quot#"
+    , "type"      : "quot# :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "templateE" : "~ARG[1] / ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.rem#"
+    , "type"      : "rem# :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "templateE" : "~ARG[1] rem ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.div#"
+    , "type"      : "div# :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "templateD" :
 "divSigned_~SYM[0] : block
   signal ~SYM[1] : ~TYP[1];
@@ -130,61 +153,73 @@ end block;"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.mod#"
+    , "type"      : "mod# :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "templateE" : "~ARG[1] mod ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.toInteger#"
+    , "type"      : "toInteger# :: Signed n -> Integer"
     , "templateE" : "to_integer(~ARG[0])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.and#"
+    , "type"      : "and# :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "templateE" : "~ARG[1] and ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.or#"
+    , "type"      : "or# :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "templateE" : "~ARG[1] or ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.xor#"
+    , "type"      : "xor# :: KnownNat n => Signed n -> Signed n -> Signed n"
     , "templateE" : "~ARG[1] xor ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.complement#"
+    , "type"      : "complement# :: KnownNat n => Signed n -> Signed n"
     , "templateE" : "not ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.shiftL#"
+    , "type"      : "shiftL# :: KnownNat n => Signed n -> Int -> Signed n"
     , "templateE" : "shift_left(~ARG[1],~ARG[2])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.shiftR#"
+    , "type"      : "shiftR# :: KnownNat n => Signed n -> Int -> Signed n"
     , "templateE" : "shift_right(~ARG[1],~ARG[2])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.rotateL#"
+    , "type"      : "rotateL# :: KnownNat n => Signed n -> Int -> Signed n"
     , "templateE" : "rotate_left(~ARG[1],~ARG[2])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.rotateR#"
+    , "type"      : "rotateR# :: KnownNat n => Signed n -> Int -> Signed n"
     , "templateE" : "rotate_right(~ARG[1],~ARG[2])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.resize#"
+    , "type"      : "resize# :: (KnownNat n, KnownNat m) => Signed n -> Signed m"
     , "templateE" : "resize(~ARG[2],~LIT[1])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Signed.truncateB#"
+    , "type"      : "truncateB# :: KnownNat m => Signed (n + m) -> Signed m"
     , "templateD" :
 "truncateB_~SYM[0] : block
   signal ~SYM[1] : ~TYP[1];

--- a/clash-vhdl/primitives/CLaSH.Sized.Internal.Unsigned.json
+++ b/clash-vhdl/primitives/CLaSH.Sized.Internal.Unsigned.json
@@ -1,162 +1,194 @@
 [ { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.size#"
+    , "type"      : "size# :: KnownNat n => Unsigned n -> Int"
     , "templateE" : "~LIT[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.pack#"
+    , "type"      : "pack# :: Unsigned n -> BitVector n"
     , "templateE" : "std_logic_vector(~ARG[0])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.unpack#"
+    , "type"      : "unpack# :: BitVector n -> Unsigned n"
     , "templateE" : "unsigned(~ARG[0])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.eq#"
+    , "type"      : "eq# :: Unsigned n -> Unsigned n -> Bool"
     , "templateE" : "~ARG[0] = ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.neq#"
+    , "type"      : "neq# :: Unsigned n -> Unsigned n -> Bool"
     , "templateE" : "~ARG[0] /= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.lt#"
+    , "type"      : "lt# :: Unsigned n -> Unsigned n -> Bool"
     , "templateE" : "~ARG[0] < ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.ge#"
+    , "type"      : "ge# :: Unsigned n -> Unsigned n -> Bool"
     , "templateE" : "~ARG[0] >= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.gt#"
+    , "type"      : "gt# :: Unsigned n -> Unsigned n -> Bool"
     , "templateE" : "~ARG[0] > ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.le#"
+    , "type"      : "le# :: Unsigned n -> Unsigned n -> Bool"
     , "templateE" : "~ARG[0] <= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.minBound#"
+    , "type"      : "minBound# :: KnownNat n => Unsigned n"
     , "comment"   : "Generates incorrect VDHL for n=0"
     , "templateE" : "unsigned'(~LIT[0]-1 downto 0 => '0');"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.maxBound#"
+    , "type"      : "maxBound# :: KnownNat n => Unsigned n"
     , "comment"   : "Generates incorrect VDHL for n=0"
     , "templateE" : "unsigned'(~LIT[0]-1 downto 0 => '1');"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.+#"
+    , "type"      : "(+#) :: KnownNat n => Unsigned n -> Unsigned n -> Unsigned n"
     , "templateE" : "~ARG[1] + ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.-#"
+    , "type"      : "(-#) :: KnownNat n => Unsigned n -> Unsigned n -> Unsigned n"
     , "templateE" : "~ARG[1] - ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.*#"
+    , "type"      : "(*#) :: KnownNat n => Unsigned n -> Unsigned n -> Unsigned n"
     , "templateE" : "resize(~ARG[1] * ~ARG[2], ~LIT[0])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.negate#"
+    , "type"      : "negate# :: KnownNat n => Unsigned n -> Unsigned n"
     , "templateE" : "unsigned(std_logic_vector(-(signed(std_logic_vector(~ARG[1])))))"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.fromInteger#"
+    , "type"      : "fromInteger# :: KnownNat n => Integer -> Unsigned n"
     , "templateE" : "to_unsigned(~ARG[1],~LIT[0])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.plus#"
+    , "type"      : "plus# :: KnownNat (1 + Max m n) => Unsigned m -> Unsigned n -> Unsigned (1 + Max m n)"
     , "templateE" : "resize(~ARG[1],~LIT[0]) + resize(~ARG[2],~LIT[0])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.minus#"
+    , "type"      : "minus# :: KnownNat (1 + Max m n) => Unsigned m -> Unsigned n -> Unsigned (1 + Max m n)"
     , "templateE" : "resize(~ARG[1],~LIT[0]) - resize(~ARG[2],~LIT[0])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.times#"
+    , "type"      : "times# :: KnownNat (m + n) => Unsigned m -> Unsigned n -> Unsigned (m + n)"
     , "templateE" : "~ARG[1] * ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.quot#"
+    , "type"      : "quot# :: Unsigned n -> Unsigned n -> Unsigned n"
     , "templateE" : "~ARG[1] / ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.rem#"
+    , "type"      : "rem# :: Unsigned n -> Unsigned n -> Unsigned n"
     , "templateE" : "~ARG[1] rem ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.mod#"
+    , "type"      : "mod# :: Unsigned n -> Unsigned n -> Unsigned n"
     , "templateE" : "~ARG[1] mod ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.toInteger#"
+    , "type"      : "toInteger# :: Unsigned n -> Integer"
     , "templateE" : "to_integer(~ARG[0])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.and#"
+    , "type"      : "and# :: Unsigned n -> Unsigned n -> Unsigned n"
     , "templateE" : "~ARG[0] and ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.or#"
+    , "type"      : "or# :: Unsigned n -> Unsigned n -> Unsigned n"
     , "templateE" : "~ARG[0] or ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.xor#"
+    , "type"      : "xor# :: Unsigned n -> Unsigned n -> Unsigned n"
     , "templateE" : "~ARG[0] xor ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.complement#"
+    , "type"      : "complement# :: KnownNat n => Unsigned n -> Unsigned n"
     , "templateE" : "not ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.shiftL#"
+    , "type"      : "shiftL# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "templateE" : "shift_left(~ARG[1],~ARG[2])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.shiftR#"
+    , "type"      : "shiftR# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "templateE" : "shift_right(~ARG[1],~ARG[2])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.rotateL#"
+    , "type"      : "rotateL# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "templateE" : "rotate_left(~ARG[1],~ARG[2])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.rotateR#"
+    , "type"      : "rotateR# :: KnownNat n => Unsigned n -> Int -> Unsigned n"
     , "templateE" : "rotate_right(~ARG[1],~ARG[2])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Internal.Unsigned.resize#"
+    , "type"      : "resize# :: KnownNat m => Unsigned n -> Unsigned m"
     , "templateE" : "resize(~ARG[1],~LIT[0])"
     }
   }

--- a/clash-vhdl/primitives/CLaSH.Sized.Vector.json
+++ b/clash-vhdl/primitives/CLaSH.Sized.Vector.json
@@ -1,15 +1,18 @@
 [ { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.eq#"
-    , "templateE" : "~ARG[0] = ~ARG[1]"
+    , "type"      : "eq# :: Eq a => Vec n a -> Vec n a -> Bool"
+    , "templateE" : "~ARG[1] = ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.neq#"
-    , "templateE" : "~ARG[0] /= ~ARG[1]"
+    , "type"      : "neq# :: Eq a => Vec n a -> Vec n a -> Bool"
+    , "templateE" : "~ARG[1] /= ~ARG[2]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.head"
+    , "type"      : "head :: Vec (n + 1) a -> a"
     , "templateD" :
 "head_~SYM[0] : block
   signal ~SYM[1] : ~TYP[0];
@@ -21,6 +24,7 @@ end block;"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.tail"
+    , "type"      : "tail :: Vec (n + 1) a -> Vec n a"
     , "templateD" :
 "tail_~SYM[0] : block
   signal ~SYM[1] : ~TYP[0];
@@ -32,6 +36,7 @@ end block;"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.last"
+    , "type"      : "Vec (n + 1) a -> a"
     , "templateD" :
 "last_~SYM[0] : block
   signal ~SYM[1] : ~TYP[0];
@@ -43,6 +48,7 @@ end block;"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.init"
+    , "type"      : "Vec (n + 1) a -> Vec n a"
     , "templateD" :
 "init_~SYM[0] : block
   signal ~SYM[1] : ~TYP[0];
@@ -53,14 +59,14 @@ end block;"
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Sized.Vector.select"
-    , "comment"   :
-    "select :: (CmpNat (i + s) (s * n) ~ GT) -- ARG[0]
-            => SNat f                        -- ARG[1]
-            -> SNat s                        -- ARG[2]
-            -> SNat n                        -- ARG[3]
-            -> Vec i a                       -- ARG[4]
-            -> Vec n a"
+    { "name" : "CLaSH.Sized.Vector.select"
+    , "type" :
+"select :: (CmpNat (i + s) (s * n) ~ GT) -- ARG[0]
+        => SNat f                        -- ARG[1]
+        -> SNat s                        -- ARG[2]
+        -> SNat n                        -- ARG[3]
+        -> Vec i a                       -- ARG[4]
+        -> Vec n a"
     , "templateD" :
 "select_~SYM[0] : block
   signal ~SYM[1] : ~TYP[4];
@@ -82,11 +88,13 @@ end block;"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.++"
+    , "type"      : "(++) :: Vec n a -> Vec m a -> Vec (n + m) a"
     , "templateE" : "~TYPM[0]'(~ARG[0]) & ~TYPM[1]'(~ARG[1])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.concat"
+    , "type"      : "concat :: Vec n (Vec m a) -> Vec (n * m) a"
     , "templateD" :
 "concat_~SYM[0] : block
   signal ~SYM[1] : ~TYP[0];
@@ -108,6 +116,7 @@ end block;"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.splitAt"
+    , "type"      : "splitAt :: SNat m -> Vec (m + n) a -> (Vec m a, Vec n a)"
     , "templateD" :
 "splitAt_~SYM[0] : block
   signal ~SYM[1] : ~TYP[1];
@@ -119,12 +128,12 @@ end block;"
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Sized.Vector.unconcat"
-    , "comment"   :
-    "unconcat :: KnownNat n     -- ARG[0]
-              => SNat m         -- ARG[1]
-              -> Vec (n * m) a  -- ARG[2]
-              -> Vec n (Vec m a)"
+    { "name" : "CLaSH.Sized.Vector.unconcat"
+    , "type" :
+"unconcat :: KnownNat n     -- ARG[0]
+          => SNat m         -- ARG[1]
+          -> Vec (n * m) a  -- ARG[2]
+          -> Vec n (Vec m a)"
     , "templateD" :
 "unconcat_~SYM[0] : block
   signal ~SYM[1] : ~TYP[2];
@@ -146,6 +155,7 @@ end block;"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.merge"
+    , "type"      : "merge :: Vec n a -> Vec n a -> Vec (n + n) a"
     , "templateD" :
 "merge_~SYM[0] : block
   signal ~SYM[1] : ~TYP[0];
@@ -170,6 +180,7 @@ end block;"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.map"
+    , "type"      : "map :: (a -> b) -> Vec n a -> Vec n b"
     , "templateD" :
 "map_~SYM[0] : block
   signal ~SYM[1] : ~TYP[1];
@@ -194,6 +205,7 @@ end block;"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.zipWith"
+    , "type"      : "zipWith :: (a -> b -> c) -> Vec n a -> Vec n b -> Vec n c"
     , "templateD" :
 "zipWith_~SYM[0] : block
   signal ~SYM[1] : ~TYP[1];
@@ -221,6 +233,7 @@ end block;"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.index_integer"
+    , "type"      : "index_integer :: KnownNat n => Vec n a -> Integer -> a"
     , "templateD" :
 "indexVec_~SYM[0] : block
   signal ~SYM[1] : ~TYP[1];
@@ -246,6 +259,7 @@ end block;"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.replace_integer"
+    , "type"      : "replace_integer :: KnownNat n => Vec n a -> Integer -> a -> Vec n a"
     , "templateD" :
 "replaceVec_~SYM[0] : block
   signal ~SYM[1] : ~TYP[1];
@@ -276,21 +290,25 @@ end block;"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.maxIndex"
+    , "type"      : "maxIndex :: KnownNat n => Vec n a -> Integer"
     , "templateE" : "~LIT[0] - 1"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.length"
+    , "type"      : "length :: KnownNat n => Vec n a -> Integer"
     , "templateE" : "~LIT[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.replicate"
+    , "type"      : "replicate :: SNat n -> a -> Vec n a"
     , "templateE" : "~TYPMO'(0 to ~LIT[0]-1 => ~ARG[1])"
     }
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.reverse"
+    , "type"      : "reverse :: Vec n a -> Vec n a"
     , "templateD" :
 "reverse_~SYM[0] : block
   signal ~SYM[1] : ~TYP[0];
@@ -311,15 +329,16 @@ end block;"
   }
 , { "BlackBox" :
     { "name"      : "CLaSH.Sized.Vector.lazyV"
+    , "type"      : "lazyV :: KnownNat n => Vec n a -> Vec n a"
     , "templateE" : "~ARG[1]"
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Sized.Vector.concatBitVector#"
-    , "comment"   :
-      "concatBitVector# :: KnownNat m           -- ARG[0]
-                        => Vec n (BitVector m)  -- ARG[1]
-                        -> BitVector (n * m)"
+    { "name" : "CLaSH.Sized.Vector.concatBitVector#"
+    , "type" :
+"concatBitVector# :: KnownNat m           -- ARG[0]
+                  => Vec n (BitVector m)  -- ARG[1]
+                  -> BitVector (n * m)"
     , "templateD" :
 "concatBitVector_~SYM[0] : block
   signal ~SYM[1] : ~TYP[1];
@@ -339,11 +358,11 @@ end block;"
     }
   }
 , { "BlackBox" :
-    { "name"      : "CLaSH.Sized.Vector.unconcatBitVector#"
-    , "comment"   :
-      "unconcatBitVector# :: (KnownNat n, KnownNat m) -- (ARG[0],ARG[1])
-                          => BitVector (n * m)        -- ARG[2]
-                          -> Vec n (BitVector m)"
+    { "name" : "CLaSH.Sized.Vector.unconcatBitVector#"
+    , "type" :
+"unconcatBitVector# :: (KnownNat n, KnownNat m) -- (ARG[0],ARG[1])
+                    => BitVector (n * m)        -- ARG[2]
+                    -> Vec n (BitVector m)"
     , "templateD" :
 "unconcatBitVector_~SYM[0] : block
   signal ~SYM[1] : ~TYP[2];

--- a/clash-vhdl/primitives/Control.Exception.Base.json
+++ b/clash-vhdl/primitives/Control.Exception.Base.json
@@ -1,20 +1,24 @@
 [ { "BlackBox" :
     { "name"      : "Control.Exception.Base.patError"
+    , "type"      : "patError :: Addr# -> a"
     , "templateE" : "~ERRORO"
     }
   }
 , { "BlackBox" :
     { "name"      : "Control.Exception.Base.irrefutPatError"
+    , "type"      : "irrefutPatError :: Addr# -> a"
     , "templateE" : "~ERRORO"
     }
   }
 , { "BlackBox" :
     { "name"      : "Control.Exception.Base.recSelError"
+    , "type"      : "recSelError :: Addr# -> a"
     , "templateE" : "~ERRORO"
     }
   }
 , { "BlackBox" :
     { "name"      : "Control.Exception.Base.absentError"
+    , "type"      : "absentError :: Addr# -> a"
     , "templateE" : "~ERRORO"
     }
   }

--- a/clash-vhdl/primitives/GHC.Base.json
+++ b/clash-vhdl/primitives/GHC.Base.json
@@ -5,16 +5,19 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Base.quotInt"
-    , "templateE" : "~ARG[0] div ~ARG[1]"
+    , "type"      : "quotInt :: Int -> Int -> Int"
+    , "templateE" : "~ARG[0] / ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Base.remInt"
+    , "type"      : "remInt :: Int -> Int -> Int"
     , "templateE" : "~ARG[0] rem ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Base.divInt"
+    , "type"      : "divInt :: Int -> Int -> Int"
     , "templateD" :
 "divInt_~SYM[0] : block
   signal ~SYM[1] : ~TYP[1];
@@ -27,6 +30,7 @@ end block;"
   }
 , { "BlackBox" :
     { "name"      : "GHC.Base.modInt"
+    , "type"      : "modInt :: Int -> Int -> Int"
     , "templateE" : "~ARG[0] mod ~ARG[1]"
     }
   }

--- a/clash-vhdl/primitives/GHC.Classes.json
+++ b/clash-vhdl/primitives/GHC.Classes.json
@@ -1,50 +1,60 @@
 [ { "BlackBox" :
     { "name"      : "GHC.Classes.eqInt"
+    , "type"      : "eqInt :: Int -> Int -> Bool"
     , "templateE" : "~ARG[0] = ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Classes.neInt"
+    , "type"      : "neInt :: Int -> Int -> Bool"
     , "templateE" : "~ARG[0] /= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Classes.gtInt"
+    , "type"      : "gtInt :: Int -> Int -> Bool"
     , "templateE" : "~ARG[0] > ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Classes.geInt"
+    , "type"      : "geInt :: Int -> Int -> Bool"
     , "templateE" : "~ARG[0] >= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Classes.ltInt"
+    , "type"      : "ltInt :: Int -> Int -> Bool"
     , "templateE" : "~ARG[0] < ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Classes.leInt"
+    , "type"      : "leInt :: Int -> Int -> Bool"
     , "templateE" : "~ARG[0] <= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Classes.&&"
+    , "type"      : "(&&) :: Bool -> Bool -> Bool"
     , "templateE" : "~ARG[0] and ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Classes.||"
+    , "type"      : "(::) :: Bool -> Bool -> Bool"
     , "templateE" : "~ARG[0] or ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Classes.not"
+    , "type"      : "not :: Bool -> Bool"
     , "templateE" : "not ~ARG[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Classes.divInt#"
+    , "type"      : "divInt# :: Int# -> Int# -> Int#"
     , "templateD" :
 "divInt_~SYM[0] : block
   signal ~SYM[1] : ~TYP[1];
@@ -57,6 +67,7 @@ end block;"
   }
 , { "BlackBox" :
     { "name"      : "GHC.Classes.modInt#"
+    , "type"      : "modInt# :: Int# -> Int# -> Int#"
     , "templateE" : "~ARG[0] mod ~ARG[1]"
     }
   }

--- a/clash-vhdl/primitives/GHC.Err.json
+++ b/clash-vhdl/primitives/GHC.Err.json
@@ -1,10 +1,12 @@
 [ { "BlackBox" :
     { "name"      : "GHC.Err.error"
+    , "type"      : "error :: [Char] -> a"
     , "templateE" : "~ERRORO"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Err.undefined"
+    , "type"      : "undefined :: a"
     , "templateE" : "~ERRORO"
     }
   }

--- a/clash-vhdl/primitives/GHC.Integer.Type.json
+++ b/clash-vhdl/primitives/GHC.Integer.Type.json
@@ -1,40 +1,48 @@
 [ { "BlackBox" :
     { "name"      : "GHC.Integer.Type.smallInteger"
+    , "type"      : "smallInteger :: Int# -> Integer"
     , "templateE" : "~ARG[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.integerToInt"
+    , "type"      : "integerToInt :: Integer -> Int#"
     , "templateE" : "~ARG[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.plusInteger"
+    , "type"      : "plusInteger :: Integer -> Integer -> Integer"
     , "templateE" : "~ARG[0] + ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.minusInteger"
+    , "type"      : "minusInteger :: Integer -> Integer -> Integer"
     , "templateE" : "~ARG[0] - ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.timesInteger"
+    , "type"      : "timesInteger :: Integer -> Integer -> Integer"
     , "templateE" : "~ARG[0] * ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.negateInteger"
+    , "type"      : "negateInteger :: Integer -> Integer"
     , "templateE" : "-~ARG[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.absInteger"
+    , "type"      : "absInteger :: Integer -> Integer"
     , "templateE" : "abs ~ARG[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.divInteger"
+    , "type"      : "divInteger :: Integer -> Integer -> Integer"
     , "templateD" :
 "divInteger_~SYM[0] : block
   signal ~SYM[1] : ~TYP[1];
@@ -47,86 +55,103 @@ end block;"
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.modInteger"
+    , "type"      : "modInteger :: Integer -> Integer -> Integer"
     , "templateE" : "~ARG[0] mod ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.quotInteger"
-    , "templateE" : "~ARG[0] div ~ARG[1]"
+    , "type"      : "quotInteger :: Integer -> Integer -> Integer"
+    , "templateE" : "~ARG[0] / ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.remInteger"
+    , "type"      : "remInteger :: Integer -> Integer -> Integer"
     , "templateE" : "~ARG[0] rem ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.eqInteger"
+    , "type"      : "eqInteger :: Integer -> Integer -> Bool"
     , "templateE" : "~ARG[0] = ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.neqInteger"
+    , "type"      : "neqInteger :: Integer -> Integer -> Bool"
     , "templateE" : "~ARG[0] /= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.leInteger"
+    , "type"      : "leInteger :: Integer -> Integer -> Bool"
     , "templateE" : "~ARG[0] <= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.gtInteger"
+    , "type"      : "gtInteger :: Integer -> Integer -> Bool"
     , "templateE" : "~ARG[0] > ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.ltInteger"
+    , "type"      : "ltInteger :: Integer -> Integer -> Bool"
     , "templateE" : "~ARG[0] < ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.geInteger"
+    , "type"      : "geInteger :: Integer -> Integer -> Bool"
     , "templateE" : "~ARG[0] >= ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.eqInteger#"
-    , "templateE" : "1 when ~ARG[0] = ~ARG[1] else 0"
+    , "type"      : "eqInteger# :: Integer -> Integer -> Int#"
+    , "templateD" : "~RESULT <= 1 when ~ARG[0] = ~ARG[1] else 0;"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.neqInteger#"
-    , "templateE" : "1 when ~ARG[0] /= ~ARG[1] else 0"
+    , "type"      : "neqInteger# :: Integer -> Integer -> Int#"
+    , "templateD" : "~RESULT <= 1 when ~ARG[0] /= ~ARG[1] else 0;"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.leInteger#"
-    , "templateE" : "1 when ~ARG[0] <= ~ARG[1] else 0"
+    , "type"      : "leInteger# :: Integer -> Integer -> Int#"
+    , "templateD" : "~RESULT <= 1 when ~ARG[0] <= ~ARG[1] else 0;"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.gtInteger#"
-    , "templateE" : "1 when ~ARG[0] > ~ARG[1] else 0"
+    , "type"      : "gtInteger# :: Integer -> Integer -> Int#"
+    , "templateD" : "~RESULT <= 1 when ~ARG[0] > ~ARG[1] else 0;"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.ltInteger#"
-    , "templateE" : "1 when ~ARG[0] < ~ARG[1] else 0"
+    , "type"      : "ltInteger# :: Integer -> Integer -> Int#"
+    , "templateD" : "~RESULT <= 1 when ~ARG[0] < ~ARG[1] else 0;"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.geInteger#"
-    , "templateE" : "1 when ~ARG[0] >= ~ARG[1] else 0"
+    , "type"      : "geInteger# :: Integer -> Integer -> Int#"
+    , "templateD" : "~RESULT <= 1 when ~ARG[0] >= ~ARG[1] else 0;"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.shiftRInteger"
+    , "type"      : "shiftRInteger :: Integer -> Int# -> Integer"
     , "templateE" : "~ARG[0] / (2**~ARG[1])"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Integer.Type.shiftLInteger"
+    , "type"      : "shiftLInteger :: Integer -> Int# -> Integer"
     , "templateE" : "~ARG[0] * (2**~ARG[1])"
     }
   }

--- a/clash-vhdl/primitives/GHC.Prim.json
+++ b/clash-vhdl/primitives/GHC.Prim.json
@@ -1,61 +1,73 @@
 [ { "BlackBox" :
     { "name"      : "GHC.Prim.+#"
+    , "type"      : "(+#) :: Int# -> Int# -> Int#"
     , "templateE" : "~ARG[0] + ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.-#"
+    , "type"      : "(-#) :: Int# -> Int# -> Int#"
     , "templateE" : "~ARG[0] - ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.*#"
+    , "type"      : "(*#) :: Int# -> Int# -> Int#"
     , "templateE" : "~ARG[0] * ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.quotInt#"
-    , "templateE" : "~ARG[0] div ~ARG[1]"
+    , "type"      : "quotInt# :: Int# -> Int# -> Int#"
+    , "templateE" : "~ARG[0] / ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.remInt#"
+    , "type"      : "remInt# :: Int# -> Int# -> Int#"
     , "templateE" : "~ARG[0] rem ~ARG[1]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.negateInt#"
+    , "type"      : "negateInt# :: Int# -> Int#"
     , "templateE" : "-~ARG[0]"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.>#"
-    , "templateE" : "1 when ~ARG[0] > ~ARG[1] else 0"
+    , "type"      : "(>#) :: Int# -> Int# -> Bool"
+    , "templateD" : "~RESULT <= 1 when ~ARG[0] > ~ARG[1] else 0;"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.>=#"
-    , "templateE" : "1 when ~ARG[0] >= ~ARG[1] else 0"
+    , "type"      : "(>=#) :: Int# -> Int# -> Bool"
+    , "templateD" : "~RESULT <= 1 when ~ARG[0] >= ~ARG[1] else 0;"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.==#"
-    , "templateE" : "1 when ~ARG[0] = ~ARG[1] else 0"
+    , "type"      : "(==) :: Int# -> Int# -> Bool"
+    , "templateD" : "~RESULT <= 1 when ~ARG[0] = ~ARG[1] else 0;"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim./=#"
-    , "templateE" : "1 when ~ARG[0] /= ~ARG[1] else 0"
+    , "type"      : "(/=#) :: Int# -> Int# -> Bool"
+    , "templateD" : "~RESULT <= 1 when ~ARG[0] /= ~ARG[1] else 0;"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.<#"
-    , "templateE" : "1 when ~ARG[0] < ~ARG[1] else 0"
+    , "type"      : "(<#) :: Int# -> Int# -> Bool"
+    , "templateD" : "~RESULT <= 1 when ~ARG[0] < ~ARG[1] else 0;"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.<=#"
-    , "templateE" : "1 when ~ARG[0] <= ~ARG[1] else 0"
+    , "type"      : "(<=#) :: Int# -> Int# -> Bool"
+    , "templateD" : "~RESULT <= 1 when ~ARG[0] <= ~ARG[1] else 0;"
     }
   }
 , { "Primitive" :
@@ -70,6 +82,7 @@
   }
 , { "BlackBox" :
     { "name"      : "GHC.Prim.unsafeCoerce#"
+    , "type"      : "unsafeCoerce# :: a -> b"
     , "templateE" : "~ARG[0]"
     }
   }

--- a/clash-vhdl/primitives/GHC.Real.json
+++ b/clash-vhdl/primitives/GHC.Real.json
@@ -1,15 +1,18 @@
 [ { "BlackBox" :
     { "name"      : "GHC.Real.divZeroError"
+    , "type"      : "divZeroError :: a"
     , "templateE" : "~ERRORO"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Real.ratioZeroDenominatorError"
+    , "type"      : "ratioZeroDenominatorError :: a"
     , "templateE" : "~ERRORO"
     }
   }
 , { "BlackBox" :
     { "name"      : "GHC.Real.overflowError"
+    , "type"      : "overflowError :: a"
     , "templateE" : "~ERRORO"
     }
   }

--- a/clash-vhdl/primitives/GHC.Typelits.json
+++ b/clash-vhdl/primitives/GHC.Typelits.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "GHC.TypeLits.natVal"
+    , "type"      : "natVal :: forall n proxy. KnownNat n => proxy n -> Integer"
     , "templateE" : "~LIT[0]"
     }
   }

--- a/clash-vhdl/primitives/Unsafe.Coerce.json
+++ b/clash-vhdl/primitives/Unsafe.Coerce.json
@@ -1,5 +1,6 @@
 [ { "BlackBox" :
     { "name"      : "Unsafe.Coerce.unsafeCoerce"
+    , "type"      : "unsafeCoerce :: a -> b"
     , "templateE" : "~ARG[0]"
     }
   }

--- a/clash-vhdl/src/CLaSH/Backend/VHDL.hs
+++ b/clash-vhdl/src/CLaSH/Backend/VHDL.hs
@@ -439,15 +439,6 @@ inst_ :: Declaration -> VHDLM (Maybe Doc)
 inst_ (Assignment id_ e) = fmap Just $
   text id_ <+> larrow <+> expr_ False e <> semi
 
--- inst_ (CondAssignment id_ scrut es) = fmap Just $
---   text id_ <+> larrow <+> align (vcat (conds es)) <> semi
---     where
---       conds :: [(Maybe Expr,Expr)] -> VHDLM [Doc]
---       conds []                = return []
---       conds [(_,e)]           = expr_ False e <:> return []
---       conds ((Nothing,e):_)   = expr_ False e <:> return []
---       conds ((Just c ,e):es') = (expr_ False e <+> "when" <+> parens (expr_ True scrut <+> "=" <+> expr_ True c) <+> "else") <:> conds es'
-
 inst_ (CondAssignment id_ scrut es) = fmap Just $
     "with" <+> parens (expr_ True scrut) <+> "select" <$>
       indent 2 (text id_ <+> larrow <+> vcat (punctuate comma (conds es)) <> semi)

--- a/clash-vhdl/src/CLaSH/Backend/VHDL.hs
+++ b/clash-vhdl/src/CLaSH/Backend/VHDL.hs
@@ -391,11 +391,11 @@ decls ds = do
     rec (dsDoc,ls) <- fmap (unzip . catMaybes) $ mapM (decl (maximum ls)) ds
     case dsDoc of
       [] -> empty
-      _  -> vcat (punctuate semi (A.pure dsDoc)) <> semi
+      _  -> punctuate' semi (A.pure dsDoc)
 
 decl :: Int ->  Declaration -> VHDLM (Maybe (Doc,Int))
-decl l (NetDecl id_ ty netInit) = Just A.<$> (,fromIntegral (T.length id_)) A.<$>
-  "signal" <+> fill l (text id_) <+> colon <+> vhdlType ty <> (maybe empty (\e -> " :=" <+> expr_ False e) netInit)
+decl l (NetDecl id_ ty) = Just A.<$> (,fromIntegral (T.length id_)) A.<$>
+  "signal" <+> fill l (text id_) <+> colon <+> vhdlType ty
 
 decl _ _ = return Nothing
 

--- a/clash-vhdl/src/CLaSH/Backend/VHDL.hs
+++ b/clash-vhdl/src/CLaSH/Backend/VHDL.hs
@@ -24,7 +24,7 @@ import qualified Data.Text.Lazy                       as T
 import           Text.PrettyPrint.Leijen.Text.Monadic
 
 import           CLaSH.Backend
-import           CLaSH.Netlist.BlackBox.Util          (renderBlackBox)
+import           CLaSH.Netlist.BlackBox.Util          (extractLiterals, renderBlackBox)
 import           CLaSH.Netlist.Types
 import           CLaSH.Netlist.Util
 import           CLaSH.Util                           (clog2, curLoc, makeCached, (<:>))
@@ -474,17 +474,17 @@ expr_ _ (DataCon ty@(Product _ _) _ es)             = tupled $ zipWithM (\i e ->
 
 expr_ _ (BlackBoxE pNm _ bbCtx _)
   | pNm == "CLaSH.Sized.Internal.Signed.fromInteger#"
-  , [Literal _ (NumLit n), Literal _ i] <- bbLitInputs bbCtx
+  , [Literal _ (NumLit n), Literal _ i] <- extractLiterals bbCtx
   = exprLit (Just (Signed (fromInteger n),fromInteger n)) i
 
 expr_ _ (BlackBoxE pNm _ bbCtx _)
   | pNm == "CLaSH.Sized.Internal.Unsigned.fromInteger#"
-  , [Literal _ (NumLit n), Literal _ i] <- bbLitInputs bbCtx
+  , [Literal _ (NumLit n), Literal _ i] <- extractLiterals bbCtx
   = exprLit (Just (Unsigned (fromInteger n),fromInteger n)) i
 
 expr_ _ (BlackBoxE pNm _ bbCtx _)
   | pNm == "CLaSH.Sized.Internal.BitVector.fromInteger#"
-  , [Literal _ (NumLit n), Literal _ i] <- bbLitInputs bbCtx
+  , [Literal _ (NumLit n), Literal _ i] <- extractLiterals bbCtx
   = exprLit (Just (BitVector (fromInteger n),fromInteger n)) i
 
 expr_ b (BlackBoxE _ bs bbCtx b') = do

--- a/clash-vhdl/src/CLaSH/Backend/VHDL.hs
+++ b/clash-vhdl/src/CLaSH/Backend/VHDL.hs
@@ -441,7 +441,7 @@ inst_ (Assignment id_ e) = fmap Just $
 
 inst_ (CondAssignment id_ scrut es) = fmap Just $
     "with" <+> parens (expr_ True scrut) <+> "select" <$>
-      indent 2 (text id_ <+> larrow <+> vcat (punctuate comma (conds es)) <> semi)
+      indent 2 (text id_ <+> larrow <+> align (vcat (punctuate comma (conds es)) <> semi))
   where
     conds :: [(Maybe Expr,Expr)] -> VHDLM [Doc]
     conds []                = return []

--- a/clash-vhdl/src/CLaSH/Backend/VHDL.hs
+++ b/clash-vhdl/src/CLaSH/Backend/VHDL.hs
@@ -439,14 +439,24 @@ inst_ :: Declaration -> VHDLM (Maybe Doc)
 inst_ (Assignment id_ e) = fmap Just $
   text id_ <+> larrow <+> expr_ False e <> semi
 
+-- inst_ (CondAssignment id_ scrut es) = fmap Just $
+--   text id_ <+> larrow <+> align (vcat (conds es)) <> semi
+--     where
+--       conds :: [(Maybe Expr,Expr)] -> VHDLM [Doc]
+--       conds []                = return []
+--       conds [(_,e)]           = expr_ False e <:> return []
+--       conds ((Nothing,e):_)   = expr_ False e <:> return []
+--       conds ((Just c ,e):es') = (expr_ False e <+> "when" <+> parens (expr_ True scrut <+> "=" <+> expr_ True c) <+> "else") <:> conds es'
+
 inst_ (CondAssignment id_ scrut es) = fmap Just $
-  text id_ <+> larrow <+> align (vcat (conds es)) <> semi
-    where
-      conds :: [(Maybe Expr,Expr)] -> VHDLM [Doc]
-      conds []                = return []
-      conds [(_,e)]           = expr_ False e <:> return []
-      conds ((Nothing,e):_)   = expr_ False e <:> return []
-      conds ((Just c ,e):es') = (expr_ False e <+> "when" <+> parens (expr_ True scrut <+> "=" <+> expr_ True c) <+> "else") <:> conds es'
+    "with" <+> parens (expr_ True scrut) <+> "select" <$>
+      indent 2 (text id_ <+> larrow <+> vcat (punctuate comma (conds es)) <> semi)
+  where
+    conds :: [(Maybe Expr,Expr)] -> VHDLM [Doc]
+    conds []                = return []
+    conds [(_,e)]           = expr_ False e <+> "when" <+> "others" <:> return []
+    conds ((Nothing,e):_)   = expr_ False e <+> "when" <+> "others" <:> return []
+    conds ((Just c ,e):es') = expr_ False e <+> "when" <+> parens (expr_ True c) <:> conds es'
 
 inst_ (InstDecl nm lbl pms) = fmap Just $
     nest 2 $ text lbl <+> colon <+> "entity"


### PR DESCRIPTION
* BlackBox ~LIT[...] holes are now properly checked.
* Primitive definitions have been augmented with their types to make the templates more understandable.
* VHDL generator no longer generates VHDL-2008 code, but generates what should be VHDL-1993 compatible code.
* VHDL generator creates select statements instead of nested conditional statements for case-expressions, significantly improving the latency in generated circuits.