### PR TITLE
Use unbound-generics

### DIFF
--- a/HACKING.MD
+++ b/HACKING.MD
@@ -14,7 +14,13 @@ Run:
 cabal sandbox init
 cabal sandbox add-source clash-lib
 cabal sandbox add-soruce clash-vhdl
-cabal sandbox add-source clash-verilog
+cabal sandbox add-source clash-systemverilog
 cabal sandbox add-source clash-ghc
 cabal sandbox add-source ../clash-prelude
+cabal install clash-ghc --dependencies-only
+```
+
+Then to work interactively with the CLaSH compiler, run:
+```
+./clash-dev
 ```

--- a/clash-dev
+++ b/clash-dev
@@ -1,2 +1,2 @@
 #!/bin/sh
-cabal exec ghci -- -iclash-lib/src -iclash-vhdl/src -iclash-systemverilog/src -iclash-ghc/src-ghc -package ghc -Wall -Werror CLaSH.hs
+cabal exec ghci -- -hide-package unbound -iclash-lib/src -iclash-vhdl/src -iclash-systemverilog/src -iclash-ghc/src-ghc -package ghc -Wall -Werror CLaSH.hs

--- a/clash-dev
+++ b/clash-dev
@@ -1,2 +1,2 @@
 #!/bin/sh
-cabal exec ghci -- -hide-package unbound -iclash-lib/src -iclash-vhdl/src -iclash-systemverilog/src -iclash-ghc/src-ghc -package ghc -Wall -Werror CLaSH.hs
+cabal exec ghci -- -iclash-lib/src -iclash-vhdl/src -iclash-systemverilog/src -iclash-ghc/src-ghc -package ghc -Wall -Werror CLaSH.hs

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -67,7 +67,7 @@ Executable clash
                       mtl                  >= 2.1.1,
                       text                 >= 0.11.3.1,
                       transformers         >= 0.3,
-                      unbound              >= 0.4.0.2,
+                      unbound-generics     >= 0.0.2.1,
                       unordered-containers >= 0.2.1.0,
 
                       clash-lib            >= 0.4.1,

--- a/clash-ghc/clash-ghc.cabal
+++ b/clash-ghc/clash-ghc.cabal
@@ -67,7 +67,7 @@ Executable clash
                       mtl                  >= 2.1.1,
                       text                 >= 0.11.3.1,
                       transformers         >= 0.3,
-                      unbound-generics     >= 0.0.2.1,
+                      unbound-generics     >= 0.1,
                       unordered-containers >= 0.2.1.0,
 
                       clash-lib            >= 0.4.1,

--- a/clash-ghc/src-bin/Main.hs
+++ b/clash-ghc/src-bin/Main.hs
@@ -64,7 +64,6 @@ import Data.Maybe
 
 -- clash additions
 import           System.Process (runInteractiveCommand, waitForProcess)
-import qualified Control.Exception as Exception
 import           Paths_clash_ghc
 import           InteractiveUI (makeHDL)
 import           Exception (gcatch)
@@ -74,12 +73,6 @@ import           Control.Exception (ErrorCall (..))
 import qualified CLaSH.Backend
 import           CLaSH.Backend.VHDL    (VHDLState)
 import           CLaSH.Backend.SystemVerilog (SystemVerilogState)
-import qualified CLaSH.Driver
-import           CLaSH.GHC.Evaluator
-import           CLaSH.GHC.GenerateBindings
-import           CLaSH.GHC.NetlistTypes
-import qualified CLaSH.Primitives.Util
-import           CLaSH.Rewrite.Types (DebugLevel(..))
 import           CLaSH.Util (clashLibVersion)
 
 ghcLibDir :: IO FilePath

--- a/clash-ghc/src-ghc/CLaSH/GHC/Evaluator.hs
+++ b/clash-ghc/src-ghc/CLaSH/GHC/Evaluator.hs
@@ -7,7 +7,7 @@ import           Data.Bits           (shiftL,shiftR)
 import qualified Data.Either         as Either
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.List           as List
-import           Unbound.LocallyNameless (bind, embed, string2Name)
+import           Unbound.Generics.LocallyNameless (bind, embed, string2Name)
 
 import           CLaSH.Core.DataCon  (dcTag)
 import           CLaSH.Core.Literal  (Literal (..))

--- a/clash-ghc/src-ghc/CLaSH/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/CLaSH/GHC/GHC2Core.hs
@@ -26,7 +26,8 @@ import qualified Data.HashMap.Strict         as HSM
 import           Data.Maybe                  (fromMaybe)
 import           Data.Text                   (isInfixOf,pack)
 import qualified Data.Traversable            as T
-import           Unbound.Generics.LocallyNameless     (Rep, bind, embed, rebind, rec,
+import           Data.Typeable               (Typeable)
+import           Unbound.Generics.LocallyNameless     (bind, embed, rebind, rec,
                                               runFreshM, string2Name, unbind,
                                               unembed)
 import qualified Unbound.Generics.LocallyNameless     as Unbound
@@ -378,7 +379,7 @@ coreToId :: Id
 coreToId i =
   C.Id <$> (coreToVar i) <*> (embed <$> coreToType (varType i))
 
-coreToVar :: Rep a
+coreToVar :: Typeable a
           => Var
           -> State GHC2CoreState (Unbound.Name a)
 coreToVar = coreToName varName varUnique qualfiedNameStringM
@@ -387,7 +388,7 @@ coreToPrimVar :: Var
               -> State GHC2CoreState (Unbound.Name C.Term)
 coreToPrimVar = coreToName varName varUnique qualfiedNameString
 
-coreToName :: Rep a
+coreToName :: Typeable a
            => (b -> Name)
            -> (b -> Unique)
            -> (Name -> State GHC2CoreState String)

--- a/clash-ghc/src-ghc/CLaSH/GHC/GHC2Core.hs
+++ b/clash-ghc/src-ghc/CLaSH/GHC/GHC2Core.hs
@@ -26,10 +26,10 @@ import qualified Data.HashMap.Strict         as HSM
 import           Data.Maybe                  (fromMaybe)
 import           Data.Text                   (isInfixOf,pack)
 import qualified Data.Traversable            as T
-import           Unbound.LocallyNameless     (Rep, bind, embed, rebind, rec,
+import           Unbound.Generics.LocallyNameless     (Rep, bind, embed, rebind, rec,
                                               runFreshM, string2Name, unbind,
                                               unembed)
-import qualified Unbound.LocallyNameless     as Unbound
+import qualified Unbound.Generics.LocallyNameless     as Unbound
 
 -- GHC API
 import           CLaSH.GHC.Compat.FastString (unpackFB, unpackFS)

--- a/clash-ghc/src-ghc/CLaSH/GHC/GenerateBindings.hs
+++ b/clash-ghc/src-ghc/CLaSH/GHC/GenerateBindings.hs
@@ -9,6 +9,7 @@ import           Data.HashMap.Strict     (HashMap)
 import qualified Data.HashMap.Strict     as HashMap
 import           Data.List               (isSuffixOf)
 import qualified Data.Set                as Set
+import qualified Data.Set.Lens           as Lens
 import           Unbound.Generics.LocallyNameless (name2String, runFreshM, unembed)
 
 import qualified CoreSyn                 as GHC
@@ -58,7 +59,7 @@ retype :: HashMap TyConName TyCon
 retype tcm (visited,bindings) current = (visited', HashMap.insert current (ty',tm') bindings')
   where
     (_,tm)               = bindings HashMap.! current
-    used                 = Set.toList $ termFreeIds tm
+    used                 = Set.toList $ Lens.setOf termFreeIds tm
     (visited',bindings') = foldl (retype tcm) (current:visited,bindings) (filter (`notElem` visited) used)
     usedTys              = map (fst . (bindings' HashMap.!)) used
     usedVars             = zipWith Var usedTys used

--- a/clash-ghc/src-ghc/CLaSH/GHC/GenerateBindings.hs
+++ b/clash-ghc/src-ghc/CLaSH/GHC/GenerateBindings.hs
@@ -9,7 +9,7 @@ import           Data.HashMap.Strict     (HashMap)
 import qualified Data.HashMap.Strict     as HashMap
 import           Data.List               (isSuffixOf)
 import qualified Data.Set                as Set
-import           Unbound.LocallyNameless (name2String, runFreshM, unembed)
+import           Unbound.Generics.LocallyNameless (name2String, runFreshM, unembed)
 
 import qualified CoreSyn                 as GHC
 import qualified DynFlags                as GHC

--- a/clash-ghc/src-ghc/CLaSH/GHC/NetlistTypes.hs
+++ b/clash-ghc/src-ghc/CLaSH/GHC/NetlistTypes.hs
@@ -6,7 +6,7 @@ where
 
 import Data.HashMap.Strict       (HashMap,(!))
 import Control.Monad.Trans.Error (ErrorT(..))
-import Unbound.LocallyNameless   (name2String)
+import Unbound.Generics.LocallyNameless   (name2String)
 
 import CLaSH.Core.Pretty         (showDoc)
 import CLaSH.Core.TyCon          (TyCon (..), TyConName)

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -75,7 +75,7 @@ Library
                       text                    >= 0.11.3.1,
                       time                    >= 1.4.0.1,
                       transformers            >= 0.3.0.0,
-                      unbound                 >= 0.4.2,
+                      unbound-generics        >= 0.0.2.1,
                       unordered-containers    >= 0.2.3.3,
                       uu-parsinglib           >= 2.8.1,
                       wl-pprint-text          >= 1.1.0.0

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -50,7 +50,7 @@ Library
   HS-Source-Dirs:     src
 
   default-language:   Haskell2010
-  ghc-options:        -O2 -Wall -fwarn-tabs
+  ghc-options:        -Wall -fwarn-tabs
   CPP-Options:        -DCABAL
 
   Build-depends:      aeson                   >= 0.6.2.0,

--- a/clash-lib/clash-lib.cabal
+++ b/clash-lib/clash-lib.cabal
@@ -75,7 +75,7 @@ Library
                       text                    >= 0.11.3.1,
                       time                    >= 1.4.0.1,
                       transformers            >= 0.3.0.0,
-                      unbound-generics        >= 0.0.2.1,
+                      unbound-generics        >= 0.1,
                       unordered-containers    >= 0.2.3.3,
                       uu-parsinglib           >= 2.8.1,
                       wl-pprint-text          >= 1.1.0.0

--- a/clash-lib/src/CLaSH/Backend.hs
+++ b/clash-lib/src/CLaSH/Backend.hs
@@ -1,7 +1,7 @@
 module CLaSH.Backend where
 
-import           Data.HashSet               (HashSet)
-import           Data.Text.Lazy                       (Text)
+import Data.HashSet                         (HashSet)
+import Data.Text.Lazy                       (Text)
 import Control.Monad.State                  (State)
 import Text.PrettyPrint.Leijen.Text.Monadic (Doc)
 

--- a/clash-lib/src/CLaSH/Core/DataCon.hs
+++ b/clash-lib/src/CLaSH/Core/DataCon.hs
@@ -16,8 +16,8 @@ module CLaSH.Core.DataCon
 where
 
 import                Control.DeepSeq
-import                Unbound.LocallyNameless as Unbound hiding (rnf)
-import                Unbound.LocallyNameless.Name (Name(Nm,Bn))
+import                Unbound.Generics.LocallyNameless as Unbound -- hiding (rnf)
+-- import                Unbound.LocallyNameless.Name (Name(Nm,Bn))
 
 import {-# SOURCE #-} CLaSH.Core.Term         (Term)
 import {-# SOURCE #-} CLaSH.Core.Type         (TyName, Type)

--- a/clash-lib/src/CLaSH/Core/DataCon.hs
+++ b/clash-lib/src/CLaSH/Core/DataCon.hs
@@ -73,6 +73,8 @@ instance Alpha DataCon where
   lfreshen' _ dc cont = cont dc mempty
   freshen' _ dc       = return (dc,mempty)
 
+  acompare' c dc1 dc2 = acompare' c (dcName dc1) (dcName dc2)
+
 instance Subst Type DataCon
 instance Subst Term DataCon
 

--- a/clash-lib/src/CLaSH/Core/DataCon.hs
+++ b/clash-lib/src/CLaSH/Core/DataCon.hs
@@ -1,10 +1,8 @@
 {-# LANGUAGE DeriveDataTypeable    #-}
 {-# LANGUAGE DeriveGeneric         #-}
-{-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE UndecidableInstances  #-}
 
 -- | Data Constructors in CoreHW
 module CLaSH.Core.DataCon
@@ -15,16 +13,16 @@ module CLaSH.Core.DataCon
   )
 where
 
-import                Data.Monoid                           (mempty)
-import                Data.Typeable
-import                Control.DeepSeq
-import                GHC.Generics
-import                Unbound.Generics.LocallyNameless      as Unbound
-import                Unbound.Generics.LocallyNameless.Name (Name(..))
+import Data.Monoid                           (mempty)
+import Data.Typeable                         (Typeable)
+import Control.DeepSeq                       (NFData(..))
+import GHC.Generics                          (Generic)
+import Unbound.Generics.LocallyNameless      (Alpha(..),Subst,substs)
+import Unbound.Generics.LocallyNameless.Name (Name(..))
 
-import {-# SOURCE #-} CLaSH.Core.Term         (Term)
-import {-# SOURCE #-} CLaSH.Core.Type         (TyName, Type)
-import                CLaSH.Util
+import {-# SOURCE #-} CLaSH.Core.Term        (Term)
+import {-# SOURCE #-} CLaSH.Core.Type        (TyName, Type)
+import CLaSH.Util
 
 -- | Data Constructor
 data DataCon

--- a/clash-lib/src/CLaSH/Core/DataCon.hs-boot
+++ b/clash-lib/src/CLaSH/Core/DataCon.hs-boot
@@ -4,12 +4,12 @@
 
 module CLaSH.Core.DataCon where
 
-import                Control.DeepSeq
-import                GHC.Generics
-import                Unbound.Generics.LocallyNameless
+import Control.DeepSeq                  (NFData)
+import GHC.Generics                     (Generic)
+import Unbound.Generics.LocallyNameless (Alpha,Subst)
 
-import {-# SOURCE #-} CLaSH.Core.Term         (Term)
-import {-# SOURCE #-} CLaSH.Core.Type         (Type)
+import {-# SOURCE #-} CLaSH.Core.Term   (Term)
+import {-# SOURCE #-} CLaSH.Core.Type   (Type)
 
 data DataCon
 

--- a/clash-lib/src/CLaSH/Core/DataCon.hs-boot
+++ b/clash-lib/src/CLaSH/Core/DataCon.hs-boot
@@ -1,19 +1,23 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
+
+{-# OPTIONS_GHC -fno-warn-missing-methods #-}
+
 module CLaSH.Core.DataCon where
 
 import                Control.DeepSeq
-import                Unbound.LocallyNameless
+import                GHC.Generics
+import                Unbound.Generics.LocallyNameless
 
 import {-# SOURCE #-} CLaSH.Core.Term         (Term)
 import {-# SOURCE #-} CLaSH.Core.Type         (Type)
 
 data DataCon
 
-instance Eq    DataCon
-instance Ord   DataCon
-instance Rep   DataCon
-instance Show  DataCon
-instance Alpha DataCon
-instance Subst Type DataCon
-instance Subst Term DataCon
-instance NFData DataCon
+instance Eq      DataCon
+instance Ord     DataCon
+instance Generic DataCon
+instance Show    DataCon
+instance Alpha   DataCon
+instance Subst   Type DataCon
+instance Subst   Term DataCon
+instance NFData  DataCon

--- a/clash-lib/src/CLaSH/Core/FreeVars.hs
+++ b/clash-lib/src/CLaSH/Core/FreeVars.hs
@@ -4,8 +4,8 @@ module CLaSH.Core.FreeVars where
 import Control.Lens.Fold                (Fold)
 import Unbound.Generics.LocallyNameless (fv)
 
-import CLaSH.Core.Term         (Term, TmName)
-import CLaSH.Core.Type         (TyName, Type)
+import CLaSH.Core.Term                  (Term, TmName)
+import CLaSH.Core.Type                  (TyName, Type)
 
 -- | Gives the free type-variables in a Type
 typeFreeVars :: Fold Type TyName

--- a/clash-lib/src/CLaSH/Core/FreeVars.hs
+++ b/clash-lib/src/CLaSH/Core/FreeVars.hs
@@ -1,31 +1,20 @@
 -- | Free variable calculations
 module CLaSH.Core.FreeVars where
 
-import Unbound.Generics.LocallyNameless (Collection, fv)
+import Control.Lens.Fold                (Fold)
+import Unbound.Generics.LocallyNameless (fv)
 
 import CLaSH.Core.Term         (Term, TmName)
 import CLaSH.Core.Type         (TyName, Type)
 
 -- | Gives the free type-variables in a Type
-typeFreeVars :: Collection c
-             => Type
-             -> c TyName
+typeFreeVars :: Fold Type TyName
 typeFreeVars = fv
 
--- | Gives the free type-variables and free term-variables of a Term
-termFreeVars :: Collection c
-             => Term
-             -> (c TyName, c TmName)
-termFreeVars tm = (termFreeTyVars tm, termFreeIds tm)
-
 -- | Gives the free term-variables of a Term
-termFreeIds :: Collection c
-            => Term
-            -> c TmName
+termFreeIds :: Fold Term TmName
 termFreeIds = fv
 
 -- | Gives the free type-variables of a Term
-termFreeTyVars :: Collection c
-               => Term
-               -> c TyName
+termFreeTyVars :: Fold Term TyName
 termFreeTyVars = fv

--- a/clash-lib/src/CLaSH/Core/FreeVars.hs
+++ b/clash-lib/src/CLaSH/Core/FreeVars.hs
@@ -1,7 +1,7 @@
 -- | Free variable calculations
 module CLaSH.Core.FreeVars where
 
-import Unbound.LocallyNameless (Collection, fv)
+import Unbound.Generics.LocallyNameless (Collection, fv)
 
 import CLaSH.Core.Term         (Term, TmName)
 import CLaSH.Core.Type         (TyName, Type)

--- a/clash-lib/src/CLaSH/Core/Literal.hs
+++ b/clash-lib/src/CLaSH/Core/Literal.hs
@@ -1,10 +1,11 @@
+{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE StandaloneDeriving    #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
-{-# OPTIONS_GHC -fno-warn-name-shadowing -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Term Literal
 module CLaSH.Core.Literal
@@ -14,31 +15,27 @@ module CLaSH.Core.Literal
 where
 
 import                Control.DeepSeq
-import                Unbound.Generics.LocallyNameless       as Unbound
-import                Unbound.Generics.LocallyNameless.Alpha
+import                GHC.Generics
+import                GHC.Real (Ratio (..))
+import                Unbound.Generics.LocallyNameless
 
 import {-# SOURCE #-} CLaSH.Core.Term               (Term)
 import {-# SOURCE #-} CLaSH.Core.Type               (Type)
 import                CLaSH.Core.TysPrim            (intPrimTy, voidPrimTy)
+import                CLaSH.Util
 
 -- | Term Literal
 data Literal
   = IntegerLiteral  Integer
   | StringLiteral   String
   | RationalLiteral Rational
-  deriving (Eq,Ord,Show)
+  deriving (Eq,Ord,Show,Generic)
 
-Unbound.derive [''Literal]
-
-instance Alpha Rational
+deriving instance Generic (Ratio a)
 instance Subst b Rational
 
 instance Alpha Literal where
-  fv' _ _ = emptyC
-
-  acompare' _ (IntegerLiteral i) (IntegerLiteral j)   = compare i j
-  acompare' _ (RationalLiteral i) (RationalLiteral j) = compare i j
-  acompare' c l1                 l2                   = acompareR1 rep1 c l1 l2
+  fvAny' _ _ l = pure l
 
 instance Subst Type Literal
 instance Subst Term Literal

--- a/clash-lib/src/CLaSH/Core/Literal.hs
+++ b/clash-lib/src/CLaSH/Core/Literal.hs
@@ -14,8 +14,8 @@ module CLaSH.Core.Literal
 where
 
 import                Control.DeepSeq
-import                Unbound.LocallyNameless       as Unbound hiding (rnf)
-import                Unbound.LocallyNameless.Alpha
+import                Unbound.Generics.LocallyNameless       as Unbound
+import                Unbound.Generics.LocallyNameless.Alpha
 
 import {-# SOURCE #-} CLaSH.Core.Term               (Term)
 import {-# SOURCE #-} CLaSH.Core.Type               (Type)

--- a/clash-lib/src/CLaSH/Core/Literal.hs
+++ b/clash-lib/src/CLaSH/Core/Literal.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE DeriveGeneric         #-}
-{-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE UndecidableInstances  #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -13,14 +11,14 @@ module CLaSH.Core.Literal
   )
 where
 
-import                Control.DeepSeq
-import                GHC.Generics
-import                Unbound.Generics.LocallyNameless
+import Control.DeepSeq                  (NFData (..))
+import GHC.Generics                     (Generic)
+import Unbound.Generics.LocallyNameless (Alpha (..), Subst (..))
 
-import {-# SOURCE #-} CLaSH.Core.Term               (Term)
-import {-# SOURCE #-} CLaSH.Core.Type               (Type)
-import                CLaSH.Core.TysPrim            (intPrimTy, voidPrimTy)
-import                CLaSH.Util
+import {-# SOURCE #-} CLaSH.Core.Term   (Term)
+import {-# SOURCE #-} CLaSH.Core.Type   (Type)
+import CLaSH.Core.TysPrim               (intPrimTy, voidPrimTy)
+import CLaSH.Util
 
 -- | Term Literal
 data Literal
@@ -32,7 +30,6 @@ data Literal
 instance Subst b Rational where
   subst  _ _ = id
   substs _   = id
-
 
 instance Alpha Literal where
   fvAny' _ _ l = pure l

--- a/clash-lib/src/CLaSH/Core/Literal.hs
+++ b/clash-lib/src/CLaSH/Core/Literal.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE StandaloneDeriving    #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -16,7 +15,6 @@ where
 
 import                Control.DeepSeq
 import                GHC.Generics
-import                GHC.Real (Ratio (..))
 import                Unbound.Generics.LocallyNameless
 
 import {-# SOURCE #-} CLaSH.Core.Term               (Term)
@@ -31,8 +29,10 @@ data Literal
   | RationalLiteral Rational
   deriving (Eq,Ord,Show,Generic)
 
-deriving instance Generic (Ratio a)
-instance Subst b Rational
+instance Subst b Rational where
+  subst  _ _ = id
+  substs _   = id
+
 
 instance Alpha Literal where
   fvAny' _ _ l = pure l

--- a/clash-lib/src/CLaSH/Core/Pretty.hs
+++ b/clash-lib/src/CLaSH/Core/Pretty.hs
@@ -9,27 +9,27 @@ module CLaSH.Core.Pretty
   )
 where
 
-import           Data.Char               (isSymbol, isUpper, ord)
-import           Data.Traversable        (sequenceA)
-import           Data.Text               (unpack)
-import           GHC.Show                (showMultiLineString)
-import           Text.PrettyPrint        (Doc, char, comma, empty, equals, hang,
-                                          hsep, int, integer, parens, punctuate,
-                                          render, sep, text, vcat, ($$), ($+$),
-                                          (<+>), (<>), rational, nest)
-import           Unbound.Generics.LocallyNameless (Embed (..), LFresh, Name, lunbind,
-                                          name2String, runLFreshM, unembed,
-                                          unrebind, unrec)
+import Data.Char                        (isSymbol, isUpper, ord)
+import Data.Traversable                 (sequenceA)
+import Data.Text                        (unpack)
+import GHC.Show                         (showMultiLineString)
+import Text.PrettyPrint                 (Doc, char, comma, empty, equals, hang,
+                                         hsep, int, integer, parens, punctuate,
+                                         render, sep, text, vcat, ($$), ($+$),
+                                         (<+>), (<>), rational, nest)
+import Unbound.Generics.LocallyNameless (Embed (..), LFresh, Name, lunbind,
+                                         name2String, runLFreshM, unembed,
+                                         unrebind, unrec)
 
-import           CLaSH.Core.DataCon      (DataCon (..))
-import           CLaSH.Core.Literal      (Literal (..))
-import           CLaSH.Core.Term         (Pat (..), Term (..))
-import           CLaSH.Core.TyCon        (TyCon (..), TyConName, isTupleTyConLike)
-import           CLaSH.Core.Type         (ConstTy (..), Kind, LitTy (..),
-                                          Type (..), TypeView (..), tyView)
-import           CLaSH.Core.Var          (Id, TyVar, Var, varKind, varName,
-                                          varType)
-import           CLaSH.Util
+import CLaSH.Core.DataCon               (DataCon (..))
+import CLaSH.Core.Literal               (Literal (..))
+import CLaSH.Core.Term                  (Pat (..), Term (..))
+import CLaSH.Core.TyCon                 (TyCon (..), TyConName, isTupleTyConLike)
+import CLaSH.Core.Type                  (ConstTy (..), Kind, LitTy (..),
+                                         Type (..), TypeView (..), tyView)
+import CLaSH.Core.Var                   (Id, TyVar, Var, varKind, varName,
+                                         varType)
+import CLaSH.Util
 
 -- | Pretty printing Show-like typeclass
 class Pretty p where

--- a/clash-lib/src/CLaSH/Core/Pretty.hs
+++ b/clash-lib/src/CLaSH/Core/Pretty.hs
@@ -17,7 +17,7 @@ import           Text.PrettyPrint        (Doc, char, comma, empty, equals, hang,
                                           hsep, int, integer, parens, punctuate,
                                           render, sep, text, vcat, ($$), ($+$),
                                           (<+>), (<>), rational, nest)
-import           Unbound.LocallyNameless (Embed (..), LFresh, Name, lunbind,
+import           Unbound.Generics.LocallyNameless (Embed (..), LFresh, Name, lunbind,
                                           name2String, runLFreshM, unembed,
                                           unrebind, unrec)
 

--- a/clash-lib/src/CLaSH/Core/Subst.hs
+++ b/clash-lib/src/CLaSH/Core/Subst.hs
@@ -1,10 +1,10 @@
 -- | Capture-free substitution function for CoreHW
 module CLaSH.Core.Subst where
 
-import                Unbound.Generics.LocallyNameless (subst, substs)
+import Unbound.Generics.LocallyNameless (subst, substs)
 
-import                CLaSH.Core.Term         (Term, TmName)
-import {-# SOURCE #-} CLaSH.Core.Type         (KiName, Kind, TyName, Type)
+import CLaSH.Core.Term                  (Term, TmName)
+import {-# SOURCE #-} CLaSH.Core.Type   (KiName, Kind, TyName, Type)
 
 -- | Substitutes types in a type
 substTys :: [(TyName,Type)]

--- a/clash-lib/src/CLaSH/Core/Subst.hs
+++ b/clash-lib/src/CLaSH/Core/Subst.hs
@@ -1,7 +1,7 @@
 -- | Capture-free substitution function for CoreHW
 module CLaSH.Core.Subst where
 
-import                Unbound.LocallyNameless (subst, substs)
+import                Unbound.Generics.LocallyNameless (subst, substs)
 
 import                CLaSH.Core.Term         (Term, TmName)
 import {-# SOURCE #-} CLaSH.Core.Type         (KiName, Kind, TyName, Type)

--- a/clash-lib/src/CLaSH/Core/Term.hs
+++ b/clash-lib/src/CLaSH/Core/Term.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveDataTypeable    #-}
+{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -17,11 +19,10 @@ where
 
 -- External Modules
 import                Control.DeepSeq
-import                Unbound.LocallyNameless       as Unbound hiding (Data,rnf)
-import                Unbound.LocallyNameless.Alpha (acompareR1, aeqR1, fvR1)
-import                Unbound.LocallyNameless.Name  (Name(Nm,Bn),isFree)
-import                Unbound.LocallyNameless.Ops   (unsafeUnbind)
 import                Data.Text                     (Text)
+import                Data.Typeable
+import                GHC.Generics
+import                Unbound.Generics.LocallyNameless
 
 -- Internal Modules
 import                CLaSH.Core.DataCon            (DataCon)
@@ -43,7 +44,7 @@ data Term
   | Letrec  (Bind (Rec [LetBinding]) Term) -- ^ Recursive let-binding
   | Case    Term Type [Bind Pat Term]      -- ^ Case-expression: subject, type of
                                            -- alternatives, list of alternatives
-  deriving Show
+  deriving (Show,Typeable,Generic)
 
 -- | Term reference
 type TmName     = Name Term
@@ -61,10 +62,8 @@ data Pat
   -- ^ Default pattern
   deriving (Show)
 
-Unbound.derive_abstract [''Text]
 instance Alpha Text
 
-Unbound.derive [''Term,''Pat]
 
 instance Eq Term where
   (==) = aeq

--- a/clash-lib/src/CLaSH/Core/Term.hs
+++ b/clash-lib/src/CLaSH/Core/Term.hs
@@ -79,12 +79,13 @@ instance Alpha Text where
   swaps' _ctx _p = id
   freshen' _ctx i = return (i, mempty)
   lfreshen' _ctx i cont = cont i mempty
+  acompare' _ctx = compare
 
 instance Eq Term where
   (==) = aeq
 
--- instance Ord Term where
---   compare = acompare
+instance Ord Term where
+  compare = acompare
 
 instance Alpha Term where
   fvAny' c nfn (Var t n)  = fmap (Var t) $ fvAny' c nfn n
@@ -93,6 +94,10 @@ instance Alpha Term where
   aeq' c (Var _ n)   (Var _ m)   = aeq' c n m
   aeq' _ (Prim t1 _) (Prim t2 _) = t1 == t2
   aeq' c t1          t2          = gaeq c (from t1) (from t2)
+
+  acompare' c (Var _ n)   (Var _ m)   = acompare' c n m
+  acompare' _ (Prim t1 _) (Prim t2 _) = compare t1 t2
+  acompare' c t1          t2          = gacompare c (from t1) (from t2)
 
 instance Alpha Pat
 

--- a/clash-lib/src/CLaSH/Core/Term.hs
+++ b/clash-lib/src/CLaSH/Core/Term.hs
@@ -1,11 +1,8 @@
 {-# LANGUAGE DeriveDataTypeable    #-}
 {-# LANGUAGE DeriveGeneric         #-}
-{-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE StandaloneDeriving    #-}
 {-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE UndecidableInstances  #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -19,21 +16,21 @@ module CLaSH.Core.Term
 where
 
 -- External Modules
-import                Control.DeepSeq
-import                Data.Monoid                             (mempty)
-import                Data.Text                               (Text)
-import                Data.Typeable
-import                GHC.Generics
-import                Unbound.Generics.LocallyNameless
-import                Unbound.Generics.LocallyNameless.Name   (Name(..))
-import                Unbound.Generics.LocallyNameless.Unsafe (unsafeUnbind)
+import Control.DeepSeq
+import Data.Monoid                             (mempty)
+import Data.Text                               (Text)
+import Data.Typeable
+import GHC.Generics
+import Unbound.Generics.LocallyNameless
+import Unbound.Generics.LocallyNameless.Name   (Name(..))
+import Unbound.Generics.LocallyNameless.Unsafe (unsafeUnbind)
 
 -- Internal Modules
-import                CLaSH.Core.DataCon            (DataCon)
-import                CLaSH.Core.Literal            (Literal)
-import {-# SOURCE #-} CLaSH.Core.Type               (Type)
-import                CLaSH.Core.Var                (Id, TyVar)
-import                CLaSH.Util
+import CLaSH.Core.DataCon                      (DataCon)
+import CLaSH.Core.Literal                      (Literal)
+import {-# SOURCE #-} CLaSH.Core.Type          (Type)
+import CLaSH.Core.Var                          (Id, TyVar)
+import CLaSH.Util
 
 -- | Term representation in the CoreHW language: System F + LetRec + Case
 data Term
@@ -66,20 +63,19 @@ data Pat
   -- ^ Default pattern
   deriving (Show,Typeable,Generic)
 
-
 instance Alpha Text where
-  aeq' _ctx = (==)
-  fvAny' _ctx _nfn i = pure i
-  close _ctx _b = id
-  open _ctx _b = id
-  isPat _ = mempty
-  isTerm _ = True
-  nthPatFind _ = Left
-  namePatFind _ _ = Left 0
-  swaps' _ctx _p = id
-  freshen' _ctx i = return (i, mempty)
+  aeq' _ctx             = (==)
+  fvAny' _ctx _nfn i    = pure i
+  close _ctx _b         = id
+  open _ctx _b          = id
+  isPat _               = mempty
+  isTerm _              = True
+  nthPatFind _          = Left
+  namePatFind _ _       = Left 0
+  swaps' _ctx _p        = id
+  freshen' _ctx i       = return (i, mempty)
   lfreshen' _ctx i cont = cont i mempty
-  acompare' _ctx = compare
+  acompare' _ctx        = compare
 
 instance Eq Term where
   (==) = aeq

--- a/clash-lib/src/CLaSH/Core/Term.hs-boot
+++ b/clash-lib/src/CLaSH/Core/Term.hs-boot
@@ -4,14 +4,14 @@
 
 module CLaSH.Core.Term where
 
-import GHC.Generics
-import Unbound.Generics.LocallyNameless
+import GHC.Generics                     (Generic)
+import Unbound.Generics.LocallyNameless (Alpha,Name,Subst)
 
 data Term
 
 type TmName = Name Term
 
-instance Generic   Term
-instance Show  Term
-instance Alpha Term
-instance Subst Term Term
+instance Generic Term
+instance Show    Term
+instance Alpha   Term
+instance Subst   Term Term

--- a/clash-lib/src/CLaSH/Core/Term.hs-boot
+++ b/clash-lib/src/CLaSH/Core/Term.hs-boot
@@ -1,13 +1,17 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
+
+{-# OPTIONS_GHC -fno-warn-missing-methods #-}
+
 module CLaSH.Core.Term where
 
-import Unbound.LocallyNameless
+import GHC.Generics
+import Unbound.Generics.LocallyNameless
 
 data Term
 
 type TmName = Name Term
 
-instance Rep   Term
+instance Generic   Term
 instance Show  Term
 instance Alpha Term
 instance Subst Term Term

--- a/clash-lib/src/CLaSH/Core/TyCon.hs
+++ b/clash-lib/src/CLaSH/Core/TyCon.hs
@@ -1,10 +1,7 @@
 {-# LANGUAGE DeriveDataTypeable    #-}
 {-# LANGUAGE DeriveGeneric         #-}
-{-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PatternGuards         #-}
-{-# LANGUAGE UndecidableInstances  #-}
 
 -- | Type Constructors in CoreHW
 module CLaSH.Core.TyCon
@@ -18,18 +15,18 @@ module CLaSH.Core.TyCon
 where
 
 -- External Import
-import                Control.DeepSeq
-import                Data.Monoid                           (mempty)
-import                Data.Typeable                         hiding (TyCon,tyConName)
-import                GHC.Generics
-import                Unbound.Generics.LocallyNameless
-import                Unbound.Generics.LocallyNameless.Name (Name(..))
+import Control.DeepSeq
+import Data.Monoid                           (mempty)
+import Data.Typeable                         hiding (TyCon,tyConName)
+import GHC.Generics
+import Unbound.Generics.LocallyNameless      (Alpha(..),Subst(..))
+import Unbound.Generics.LocallyNameless.Name (Name(..),name2String)
 
 -- Internal Imports
-import {-# SOURCE #-} CLaSH.Core.DataCon      (DataCon)
-import {-# SOURCE #-} CLaSH.Core.Term         (Term)
-import {-# SOURCE #-} CLaSH.Core.Type         (Kind, TyName, Type)
-import                CLaSH.Util
+import {-# SOURCE #-} CLaSH.Core.DataCon     (DataCon)
+import {-# SOURCE #-} CLaSH.Core.Term        (Term)
+import {-# SOURCE #-} CLaSH.Core.Type        (Kind, TyName, Type)
+import CLaSH.Util
 
 -- | Type Constructor
 data TyCon

--- a/clash-lib/src/CLaSH/Core/TyCon.hs
+++ b/clash-lib/src/CLaSH/Core/TyCon.hs
@@ -107,6 +107,8 @@ instance Alpha TyCon where
   lfreshen' _ tc cont = cont tc mempty
   freshen' _ tc       = return (tc,mempty)
 
+  acompare' c tc1 tc2 = acompare' c (tyConName tc1) (tyConName tc2)
+
 
 instance Alpha AlgTyConRhs
 

--- a/clash-lib/src/CLaSH/Core/TyCon.hs
+++ b/clash-lib/src/CLaSH/Core/TyCon.hs
@@ -6,8 +6,6 @@
 {-# LANGUAGE PatternGuards         #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
-{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
-
 -- | Type Constructors in CoreHW
 module CLaSH.Core.TyCon
   ( TyCon (..)
@@ -120,10 +118,10 @@ instance Subst Term AlgTyConRhs
 
 instance NFData TyCon where
   rnf tc = case tc of
-    AlgTyCon nm ki ar rhs   -> rnf nm `seq` rnf ki `seq` rnf ar `seq` rnf rhs
-    FunTyCon nm ki ar subst -> rnf nm `seq` rnf ki `seq` rnf ar `seq` rnf subst
-    PrimTyCon nm ki ar      -> rnf nm `seq` rnf ki `seq` rnf ar
-    SuperKindTyCon nm       -> rnf nm
+    AlgTyCon nm ki ar rhs     -> rnf nm `seq` rnf ki `seq` rnf ar `seq` rnf rhs
+    FunTyCon nm ki ar tcSubst -> rnf nm `seq` rnf ki `seq` rnf ar `seq` rnf tcSubst
+    PrimTyCon nm ki ar        -> rnf nm `seq` rnf ki `seq` rnf ar
+    SuperKindTyCon nm         -> rnf nm
 
 instance NFData (Name TyCon) where
   rnf nm = case nm of
@@ -146,10 +144,10 @@ mkKindTyCon name kind
 isTupleTyConLike :: TyConName -> Bool
 isTupleTyConLike nm = tupleName (name2String nm)
   where
-    tupleName nm
-      | '(' <- head nm
-      , ')' <- last nm
-      = all (== ',') (init $ tail nm)
+    tupleName nm'
+      | '(' <- head nm'
+      , ')' <- last nm'
+      = all (== ',') (init $ tail nm')
     tupleName _ = False
 
 -- | Get the DataCons belonging to a TyCon

--- a/clash-lib/src/CLaSH/Core/TyCon.hs
+++ b/clash-lib/src/CLaSH/Core/TyCon.hs
@@ -90,7 +90,7 @@ data AlgTyConRhs
   deriving (Show,Generic)
 
 instance Alpha TyCon where
-  aeq' _ tc1 tc2      = aeq (tyConName tc1) (tyConName tc2)
+  aeq' c tc1 tc2      = aeq' c (tyConName tc1) (tyConName tc2)
 
   fvAny' _ _ tc       = pure tc
 

--- a/clash-lib/src/CLaSH/Core/TyCon.hs
+++ b/clash-lib/src/CLaSH/Core/TyCon.hs
@@ -1,8 +1,9 @@
+{-# LANGUAGE DeriveDataTypeable    #-}
+{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PatternGuards         #-}
-{-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
@@ -20,8 +21,11 @@ where
 
 -- External Import
 import                Control.DeepSeq
-import                Unbound.LocallyNameless as Unbound hiding (rnf)
-import                Unbound.LocallyNameless.Name (Name(Nm,Bn))
+import                Data.Monoid                           (mempty)
+import                Data.Typeable                         hiding (TyCon,tyConName)
+import                GHC.Generics
+import                Unbound.Generics.LocallyNameless
+import                Unbound.Generics.LocallyNameless.Name (Name(..))
 
 -- Internal Imports
 import {-# SOURCE #-} CLaSH.Core.DataCon      (DataCon)
@@ -55,6 +59,7 @@ data TyCon
   | SuperKindTyCon
   { tyConName :: TyConName     -- ^ Name of the TyCon
   }
+  deriving (Generic,Typeable)
 
 instance Show TyCon where
   show (AlgTyCon       {tyConName = n}) = "AlgTyCon: " ++ show n
@@ -84,24 +89,26 @@ data AlgTyConRhs
                                  -- The TyName's are the type-variables from
                                  -- the corresponding TyCon.
   }
-  deriving Show
-
-Unbound.derive [''TyCon,''AlgTyConRhs]
+  deriving (Show,Generic)
 
 instance Alpha TyCon where
-  swaps' _ _ d    = d
-  fv' _ _         = emptyC
-  lfreshen' _ a f = f a empty
-  freshen' _ a    = return (a,empty)
-  aeq' _ tc1 tc2  = aeq (tyConName tc1) (tyConName tc2)
-  acompare' _ tc1 tc2 = acompare (tyConName tc1) (tyConName tc2)
-  open _ _ d      = d
-  close _ _ d     = d
-  isPat _         = error "isPat TyCon"
-  isTerm _        = error "isTerm TyCon"
-  isEmbed _       = error "isEmbed TyCon"
-  nthpatrec _     = error "nthpatrec TyCon"
-  findpatrec _ _  = error "findpatrec TyCon"
+  aeq' _ tc1 tc2      = aeq (tyConName tc1) (tyConName tc2)
+
+  fvAny' _ _ tc       = pure tc
+
+  close _ _ tc        = tc
+  open _ _ tc         = tc
+
+  isPat _             = mempty
+  isTerm _            = True
+
+  nthPatFind _        = Left
+  namePatFind _ _     = Left 0
+
+  swaps' _ _ tc       = tc
+  lfreshen' _ tc cont = cont tc mempty
+  freshen' _ tc       = return (tc,mempty)
+
 
 instance Alpha AlgTyConRhs
 
@@ -120,8 +127,8 @@ instance NFData TyCon where
 
 instance NFData (Name TyCon) where
   rnf nm = case nm of
-    (Nm _ s)   -> rnf s
-    (Bn _ l r) -> rnf l `seq` rnf r
+    (Fn s i) -> rnf s `seq` rnf i
+    (Bn l r) -> rnf l `seq` rnf r
 
 instance NFData AlgTyConRhs where
   rnf rhs = case rhs of

--- a/clash-lib/src/CLaSH/Core/TyCon.hs-boot
+++ b/clash-lib/src/CLaSH/Core/TyCon.hs-boot
@@ -1,6 +1,6 @@
 module CLaSH.Core.TyCon where
 
-import Unbound.LocallyNameless (Name)
+import Unbound.Generics.LocallyNameless (Name)
 
 data TyCon
 type TyConName = Name TyCon

--- a/clash-lib/src/CLaSH/Core/Type.hs
+++ b/clash-lib/src/CLaSH/Core/Type.hs
@@ -6,10 +6,6 @@
 {-# LANGUAGE UndecidableInstances  #-}
 {-# LANGUAGE ViewPatterns          #-}
 
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 707
-{-# OPTIONS_GHC -fno-warn-duplicate-constraints #-}
-#endif
-
 -- | Types in CoreHW
 module CLaSH.Core.Type
   ( Type (..)

--- a/clash-lib/src/CLaSH/Core/Type.hs
+++ b/clash-lib/src/CLaSH/Core/Type.hs
@@ -105,6 +105,9 @@ instance Alpha Type where
   aeq' c (VarTy _ n) (VarTy _ m) = aeq' c n m
   aeq' c t1          t2          = gaeq c (from t1) (from t2)
 
+  acompare' c (VarTy _ n) (VarTy _ m) = acompare' c n m
+  acompare' c t1          t2          = gacompare c (from t1) (from t2)
+
 instance Alpha ConstTy
 instance Alpha LitTy
 
@@ -119,6 +122,9 @@ instance Subst Type Type where
 
 instance Eq Type where
   (==) = aeq
+
+instance Ord Type where
+  compare = acompare
 
 instance NFData Type where
   rnf ty = case ty of

--- a/clash-lib/src/CLaSH/Core/Type.hs
+++ b/clash-lib/src/CLaSH/Core/Type.hs
@@ -1,11 +1,8 @@
-{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DeriveDataTypeable    #-}
 {-# LANGUAGE DeriveGeneric         #-}
-{-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE UndecidableInstances  #-}
 {-# LANGUAGE ViewPatterns          #-}
 
 -- | Types in CoreHW
@@ -41,24 +38,29 @@ module CLaSH.Core.Type
 where
 
 -- External import
-import                Control.DeepSeq                   as DS
-import                Control.Monad                     (zipWithM)
-import                Data.HashMap.Strict               (HashMap)
-import qualified      Data.HashMap.Strict               as HashMap
-import                Data.Maybe                        (isJust)
-import                Data.Typeable                     hiding (TyCon,mkFunTy,mkTyConApp)
-import                GHC.Generics
-import                Unbound.Generics.LocallyNameless
-import                Unbound.Generics.LocallyNameless.Name   (Name(..))
-import                Unbound.Generics.LocallyNameless.Unsafe (unsafeUnbind)
+import           Control.DeepSeq                         as DS
+import           Control.Monad                           (zipWithM)
+import           Data.HashMap.Strict                     (HashMap)
+import qualified Data.HashMap.Strict                     as HashMap
+import           Data.Maybe                              (isJust)
+import           Data.Typeable                           hiding (TyCon,mkFunTy,
+                                                          mkTyConApp)
+import           GHC.Generics                            (Generic(..))
+import           Unbound.Generics.LocallyNameless        (Alpha(..),Bind,Fresh,
+                                                          Subst(..),SubstName(..),
+                                                          acompare,aeq,bind,
+                                                          gacompare,gaeq,gfvAny,
+                                                          runFreshM,unbind)
+import           Unbound.Generics.LocallyNameless.Name   (Name(..), name2String)
+import           Unbound.Generics.LocallyNameless.Unsafe (unsafeUnbind)
 
 -- Local imports
-import                CLaSH.Core.Subst
+import           CLaSH.Core.Subst
 import {-# SOURCE #-} CLaSH.Core.Term
-import                CLaSH.Core.TyCon
-import                CLaSH.Core.TysPrim
-import                CLaSH.Core.Var
-import                CLaSH.Util
+import           CLaSH.Core.TyCon
+import           CLaSH.Core.TysPrim
+import           CLaSH.Core.Var
+import           CLaSH.Util
 
 -- | Types in CoreHW: function and polymorphic types
 data Type

--- a/clash-lib/src/CLaSH/Core/Type.hs
+++ b/clash-lib/src/CLaSH/Core/Type.hs
@@ -48,10 +48,10 @@ import                Control.Monad                 (zipWithM)
 import                Data.HashMap.Strict           (HashMap)
 import qualified      Data.HashMap.Strict           as HashMap
 import                Data.Maybe                    (isJust)
-import                Unbound.LocallyNameless       as Unbound hiding (Arrow,rnf)
-import                Unbound.LocallyNameless.Alpha (aeqR1,fvR1)
-import                Unbound.LocallyNameless.Name  (Name(Nm,Bn))
-import                Unbound.LocallyNameless.Ops   (unsafeUnbind)
+import                Unbound.Generics.LocallyNameless       as Unbound -- hiding (Arrow,rnf)
+-- import                Unbound.LocallyNameless.Alpha (aeqR1,fvR1)
+-- import                Unbound.LocallyNameless.Name  (Name(Nm,Bn))
+-- import                Unbound.LocallyNameless.Ops   (unsafeUnbind)
 
 -- Local imports
 import                CLaSH.Core.Subst

--- a/clash-lib/src/CLaSH/Core/Type.hs-boot
+++ b/clash-lib/src/CLaSH/Core/Type.hs-boot
@@ -5,10 +5,10 @@
 
 module CLaSH.Core.Type where
 
-import                Control.DeepSeq
-import                Data.Typeable
-import                GHC.Generics
-import                Unbound.Generics.LocallyNameless
+import Control.DeepSeq
+import Data.Typeable
+import GHC.Generics
+import Unbound.Generics.LocallyNameless
 
 import {-# SOURCE #-} CLaSH.Core.Term
 import {-# SOURCE #-} CLaSH.Core.TyCon
@@ -19,14 +19,14 @@ type Kind   = Type
 type TyName = Name Type
 type KiName = Name Kind
 
-instance Eq    Type
-instance Generic   Type
-instance Show  Type
-instance Alpha Type
-instance Subst Type Type
-instance Subst Term Type
-instance NFData Type
-instance NFData (Name Type)
+instance Eq       Type
+instance Generic  Type
+instance Show     Type
+instance Alpha    Type
+instance Subst    Type Type
+instance Subst    Term Type
+instance NFData   Type
+instance NFData   (Name Type)
 instance Typeable Type
 
 mkTyConTy :: TyConName -> Type

--- a/clash-lib/src/CLaSH/Core/Type.hs-boot
+++ b/clash-lib/src/CLaSH/Core/Type.hs-boot
@@ -1,9 +1,14 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+
+{-# OPTIONS_GHC -fno-warn-missing-methods #-}
+
 module CLaSH.Core.Type where
 
 import                Control.DeepSeq
-import                Unbound.LocallyNameless
+import                Data.Typeable
+import                GHC.Generics
+import                Unbound.Generics.LocallyNameless
 
 import {-# SOURCE #-} CLaSH.Core.Term
 import {-# SOURCE #-} CLaSH.Core.TyCon
@@ -16,12 +21,13 @@ type KiName = Name Kind
 
 instance Eq    Type
 instance Ord   Type
-instance Rep   Type
+instance Generic   Type
 instance Show  Type
 instance Alpha Type
 instance Subst Type Type
 instance Subst Term Type
 instance NFData Type
 instance NFData (Name Type)
+instance Typeable Type
 
 mkTyConTy :: TyConName -> Type

--- a/clash-lib/src/CLaSH/Core/Type.hs-boot
+++ b/clash-lib/src/CLaSH/Core/Type.hs-boot
@@ -20,7 +20,6 @@ type TyName = Name Type
 type KiName = Name Kind
 
 instance Eq    Type
-instance Ord   Type
 instance Generic   Type
 instance Show  Type
 instance Alpha Type

--- a/clash-lib/src/CLaSH/Core/TysPrim.hs
+++ b/clash-lib/src/CLaSH/Core/TysPrim.hs
@@ -9,11 +9,11 @@ module CLaSH.Core.TysPrim
   )
 where
 
-import                Data.HashMap.Strict     (HashMap)
-import qualified      Data.HashMap.Strict     as HashMap
-import                Unbound.Generics.LocallyNameless (string2Name)
+import           Data.HashMap.Strict              (HashMap)
+import qualified Data.HashMap.Strict              as HashMap
+import           Unbound.Generics.LocallyNameless (string2Name)
 
-import                CLaSH.Core.TyCon
+import           CLaSH.Core.TyCon
 import {-# SOURCE #-} CLaSH.Core.Type
 
 -- | Builtin Name

--- a/clash-lib/src/CLaSH/Core/TysPrim.hs
+++ b/clash-lib/src/CLaSH/Core/TysPrim.hs
@@ -11,7 +11,7 @@ where
 
 import                Data.HashMap.Strict     (HashMap)
 import qualified      Data.HashMap.Strict     as HashMap
-import                Unbound.LocallyNameless (string2Name)
+import                Unbound.Generics.LocallyNameless (string2Name)
 
 import                CLaSH.Core.TyCon
 import {-# SOURCE #-} CLaSH.Core.Type

--- a/clash-lib/src/CLaSH/Core/Util.hs
+++ b/clash-lib/src/CLaSH/Core/Util.hs
@@ -6,9 +6,9 @@
 module CLaSH.Core.Util where
 
 import           Data.HashMap.Lazy       (HashMap)
-import           Unbound.LocallyNameless (Fresh, bind, embed, unbind, unembed,
+import           Unbound.Generics.LocallyNameless (Fresh, bind, embed, unbind, unembed,
                                           unrebind, unrec)
-import           Unbound.LocallyNameless.Ops (unsafeUnbind)
+-- import           Unbound.LocallyNameless.Ops (unsafeUnbind)
 
 import           CLaSH.Core.DataCon      (dcType)
 import           CLaSH.Core.Literal      (literalType)

--- a/clash-lib/src/CLaSH/Core/Util.hs
+++ b/clash-lib/src/CLaSH/Core/Util.hs
@@ -8,7 +8,7 @@ module CLaSH.Core.Util where
 import           Data.HashMap.Lazy       (HashMap)
 import           Unbound.Generics.LocallyNameless (Fresh, bind, embed, unbind, unembed,
                                           unrebind, unrec)
--- import           Unbound.LocallyNameless.Ops (unsafeUnbind)
+import           Unbound.Generics.LocallyNameless.Unsafe (unsafeUnbind)
 
 import           CLaSH.Core.DataCon      (dcType)
 import           CLaSH.Core.Literal      (literalType)

--- a/clash-lib/src/CLaSH/Core/Util.hs
+++ b/clash-lib/src/CLaSH/Core/Util.hs
@@ -1,25 +1,23 @@
 {-# LANGUAGE TemplateHaskell #-}
 
-{-# OPTIONS_GHC -fcontext-stack=21 #-}
-
 -- | Smart constructor and destructor functions for CoreHW
 module CLaSH.Core.Util where
 
-import           Data.HashMap.Lazy       (HashMap)
-import           Unbound.Generics.LocallyNameless (Fresh, bind, embed, unbind, unembed,
-                                          unrebind, unrec)
-import           Unbound.Generics.LocallyNameless.Unsafe (unsafeUnbind)
+import Data.HashMap.Lazy                       (HashMap)
+import Unbound.Generics.LocallyNameless        (Fresh, bind, embed, unbind, unembed,
+                                                unrebind, unrec)
+import Unbound.Generics.LocallyNameless.Unsafe (unsafeUnbind)
 
-import           CLaSH.Core.DataCon      (dcType)
-import           CLaSH.Core.Literal      (literalType)
-import           CLaSH.Core.Pretty       (showDoc)
-import           CLaSH.Core.Term         (Pat (..), Term (..), TmName)
-import           CLaSH.Core.Type         (Kind, TyName, Type (..), applyTy,
-                                          isFunTy, isPolyFunCoreTy, mkFunTy,
-                                          splitFunTy)
-import           CLaSH.Core.TyCon        (TyCon, TyConName)
-import           CLaSH.Core.Var          (Id, TyVar, Var (..), varType)
-import           CLaSH.Util
+import CLaSH.Core.DataCon                      (dcType)
+import CLaSH.Core.Literal                      (literalType)
+import CLaSH.Core.Pretty                       (showDoc)
+import CLaSH.Core.Term                         (Pat (..), Term (..), TmName)
+import CLaSH.Core.Type                         (Kind, TyName, Type (..), applyTy,
+                                                isFunTy, isPolyFunCoreTy, mkFunTy,
+                                                splitFunTy)
+import CLaSH.Core.TyCon                        (TyCon, TyConName)
+import CLaSH.Core.Var                          (Id, TyVar, Var (..), varType)
+import CLaSH.Util
 
 -- | Type environment/context
 type Gamma = HashMap TmName Type

--- a/clash-lib/src/CLaSH/Core/Var.hs
+++ b/clash-lib/src/CLaSH/Core/Var.hs
@@ -38,7 +38,7 @@ data Var a
   { varName :: Name a
   , varType :: Embed Type
   }
-  deriving (Eq,Ord,Show,Generic,Typeable)
+  deriving (Eq,Show,Generic,Typeable)
 
 -- | Term variable
 type Id    = Var Term

--- a/clash-lib/src/CLaSH/Core/Var.hs
+++ b/clash-lib/src/CLaSH/Core/Var.hs
@@ -8,11 +8,6 @@
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
-{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 707
-{-# OPTIONS_GHC -fno-warn-duplicate-constraints #-}
-#endif
-
 -- | Variables in CoreHW
 module CLaSH.Core.Var
   ( Var (..)

--- a/clash-lib/src/CLaSH/Core/Var.hs
+++ b/clash-lib/src/CLaSH/Core/Var.hs
@@ -17,14 +17,15 @@ module CLaSH.Core.Var
   )
 where
 
-import                Control.DeepSeq
-import                Data.Typeable
-import                GHC.Generics
-import                Unbound.Generics.LocallyNameless
+import Control.DeepSeq                  (NFData (..))
+import Data.Typeable                    (Typeable)
+import GHC.Generics                     (Generic)
+import Unbound.Generics.LocallyNameless (Alpha,Embed,Name,Subst(..),isFreeName,
+                                         unembed)
 
-import {-# SOURCE #-} CLaSH.Core.Term                  (Term)
-import {-# SOURCE #-} CLaSH.Core.Type                  (Kind, Type)
-import                CLaSH.Util
+import {-# SOURCE #-} CLaSH.Core.Term   (Term)
+import {-# SOURCE #-} CLaSH.Core.Type   (Kind, Type)
+import CLaSH.Util
 
 -- | Variables in CoreHW
 data Var a

--- a/clash-lib/src/CLaSH/Driver.hs
+++ b/clash-lib/src/CLaSH/Driver.hs
@@ -17,7 +17,7 @@ import qualified System.Directory             as Directory
 import qualified System.FilePath              as FilePath
 import qualified System.IO                    as IO
 import           Text.PrettyPrint.Leijen.Text (Doc, hPutDoc)
-import           Unbound.LocallyNameless      (name2String)
+import           Unbound.Generics.LocallyNameless      (name2String)
 
 import           CLaSH.Backend
 import           CLaSH.Core.Term              (Term)

--- a/clash-lib/src/CLaSH/Driver.hs
+++ b/clash-lib/src/CLaSH/Driver.hs
@@ -4,36 +4,35 @@
 -- | Module that connects all the parts of the CLaSH compiler library
 module CLaSH.Driver where
 
-import qualified Control.Concurrent.Supply    as Supply
+import qualified Control.Concurrent.Supply        as Supply
 import           Control.DeepSeq
-import           Control.Monad.State          (evalState, get)
-import           Data.HashMap.Strict          (HashMap)
-import qualified Data.HashMap.Strict          as HashMap
-import qualified Data.HashSet                 as HashSet
-import           Data.List                    (isSuffixOf)
-import           Data.Maybe                   (fromMaybe, listToMaybe)
-import qualified Data.Text.Lazy               as Text
-import qualified System.Directory             as Directory
-import qualified System.FilePath              as FilePath
-import qualified System.IO                    as IO
-import           Text.PrettyPrint.Leijen.Text (Doc, hPutDoc)
-import           Unbound.Generics.LocallyNameless      (name2String)
+import           Control.Monad.State              (evalState, get)
+import           Data.HashMap.Strict              (HashMap)
+import qualified Data.HashMap.Strict              as HashMap
+import qualified Data.HashSet                     as HashSet
+import           Data.List                        (isSuffixOf)
+import           Data.Maybe                       (fromMaybe, listToMaybe)
+import qualified Data.Text.Lazy                   as Text
+import qualified Data.Time.Clock                  as Clock
+import qualified System.Directory                 as Directory
+import qualified System.FilePath                  as FilePath
+import qualified System.IO                        as IO
+import           Text.PrettyPrint.Leijen.Text     (Doc, hPutDoc)
+import           Unbound.Generics.LocallyNameless (name2String)
 
 import           CLaSH.Backend
-import           CLaSH.Core.Term              (Term)
-import           CLaSH.Core.Type              (Type)
-import           CLaSH.Core.TyCon             (TyCon, TyConName)
+import           CLaSH.Core.Term                  (Term)
+import           CLaSH.Core.Type                  (Type)
+import           CLaSH.Core.TyCon                 (TyCon, TyConName)
 import           CLaSH.Driver.TestbenchGen
 import           CLaSH.Driver.Types
-import           CLaSH.Netlist                (genNetlist)
-import           CLaSH.Netlist.Types          (Component (..), HWType)
-import           CLaSH.Normalize              (checkNonRecursive, cleanupGraph,
-                                               normalize, runNormalization)
+import           CLaSH.Netlist                    (genNetlist)
+import           CLaSH.Netlist.Types              (Component (..), HWType)
+import           CLaSH.Normalize                  (checkNonRecursive, cleanupGraph,
+                                                   normalize, runNormalization)
 import           CLaSH.Primitives.Types
-import           CLaSH.Rewrite.Types          (DebugLevel (..))
+import           CLaSH.Rewrite.Types              (DebugLevel (..))
 import           CLaSH.Util
-
-import qualified Data.Time.Clock              as Clock
 
 -- | Create a set of target HDL files for a set of functions
 generateHDL :: forall backend . Backend backend

--- a/clash-lib/src/CLaSH/Driver/TestbenchGen.hs
+++ b/clash-lib/src/CLaSH/Driver/TestbenchGen.hs
@@ -15,7 +15,7 @@ import qualified Data.HashMap.Lazy                as HashMap
 import           Data.List                        (find,nub)
 import           Data.Maybe                       (mapMaybe)
 import           Data.Text.Lazy                   (isPrefixOf,pack,splitOn)
-import           Unbound.LocallyNameless          (name2String)
+import           Unbound.Generics.LocallyNameless          (name2String)
 
 import           CLaSH.Core.Term
 import           CLaSH.Core.TyCon

--- a/clash-lib/src/CLaSH/Driver/TestbenchGen.hs
+++ b/clash-lib/src/CLaSH/Driver/TestbenchGen.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
 
-{-# OPTIONS_GHC -fcontext-stack=21 #-}
-
 -- | Generate a HDL testbench for a component given a set of stimuli and a
 -- set of matching expected outputs
 module CLaSH.Driver.TestbenchGen

--- a/clash-lib/src/CLaSH/Netlist.hs
+++ b/clash-lib/src/CLaSH/Netlist.hs
@@ -1,39 +1,38 @@
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections   #-}
 
 -- | Create Netlists out of normalized CoreHW Terms
 module CLaSH.Netlist where
 
-import           Control.Lens               ((.=), (<<%=))
-import qualified Control.Lens               as Lens
-import           Control.Monad.State        (runStateT)
-import           Control.Monad.Writer       (listen, runWriterT)
-import           Data.Either                (lefts,partitionEithers)
-import           Data.HashMap.Lazy          (HashMap)
-import qualified Data.HashMap.Lazy          as HashMap
-import           Data.List                  (elemIndex, nub)
-import           Data.Maybe                 (fromMaybe)
-import qualified Data.Text.Lazy             as Text
-import           Unbound.Generics.LocallyNameless    (Embed (..), name2String,
-                                             runFreshMT, unbind, unembed,
-                                             unrebind)
+import           Control.Lens                     ((.=), (<<%=))
+import qualified Control.Lens                     as Lens
+import           Control.Monad.State              (runStateT)
+import           Control.Monad.Writer             (listen, runWriterT)
+import           Data.Either                      (lefts,partitionEithers)
+import           Data.HashMap.Lazy                (HashMap)
+import qualified Data.HashMap.Lazy                as HashMap
+import           Data.List                        (elemIndex, nub)
+import           Data.Maybe                       (fromMaybe)
+import qualified Data.Text.Lazy                   as Text
+import           Unbound.Generics.LocallyNameless (Embed (..), name2String,
+                                                  runFreshMT, unbind, unembed,
+                                                  unrebind)
 
-import           CLaSH.Core.DataCon         (DataCon (..))
-import           CLaSH.Core.Literal         (Literal (..))
-import           CLaSH.Core.Pretty          (showDoc)
-import           CLaSH.Core.Term            (Pat (..), Term (..), TmName)
-import qualified CLaSH.Core.Term            as Core
-import           CLaSH.Core.Type            (Type (..))
-import           CLaSH.Core.TyCon           (TyConName, TyCon)
-import           CLaSH.Core.Util            (collectArgs, isVar, termType)
-import           CLaSH.Core.Var             (Id, Var (..))
+import           CLaSH.Core.DataCon               (DataCon (..))
+import           CLaSH.Core.Literal               (Literal (..))
+import           CLaSH.Core.Pretty                (showDoc)
+import           CLaSH.Core.Term                  (Pat (..), Term (..), TmName)
+import qualified CLaSH.Core.Term                  as Core
+import           CLaSH.Core.Type                  (Type (..))
+import           CLaSH.Core.TyCon                 (TyConName, TyCon)
+import           CLaSH.Core.Util                  (collectArgs, isVar, termType)
+import           CLaSH.Core.Var                   (Id, Var (..))
 import           CLaSH.Netlist.BlackBox
 import           CLaSH.Netlist.Id
-import           CLaSH.Netlist.Types        as HW
+import           CLaSH.Netlist.Types              as HW
 import           CLaSH.Netlist.Util
 import           CLaSH.Normalize.Util
-import           CLaSH.Primitives.Types     as P
+import           CLaSH.Primitives.Types           as P
 import           CLaSH.Util
 
 -- | Generate a hierarchical netlist out of a set of global binders with

--- a/clash-lib/src/CLaSH/Netlist.hs
+++ b/clash-lib/src/CLaSH/Netlist.hs
@@ -15,7 +15,7 @@ import qualified Data.HashMap.Lazy          as HashMap
 import           Data.List                  (elemIndex, nub)
 import           Data.Maybe                 (fromMaybe)
 import qualified Data.Text.Lazy             as Text
-import           Unbound.LocallyNameless    (Embed (..), name2String,
+import           Unbound.Generics.LocallyNameless    (Embed (..), name2String,
                                              runFreshMT, unbind, unembed,
                                              unrebind)
 

--- a/clash-lib/src/CLaSH/Netlist/BlackBox.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox.hs
@@ -18,7 +18,7 @@ import           Data.Text.Lazy                (Text, fromStrict, pack)
 import qualified Data.Text.Lazy                as Text
 import           Data.Text                     (unpack)
 import qualified Data.Text                     as TextS
-import           Unbound.LocallyNameless       (embed, name2String, string2Name,
+import           Unbound.Generics.LocallyNameless       (embed, name2String, string2Name,
                                                 unembed)
 
 -- import           CLaSH.Backend                 as N

--- a/clash-lib/src/CLaSH/Netlist/BlackBox.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternGuards     #-}
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TupleSections     #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 -- | Functions to create BlackBox Contexts and fill in BlackBox templates
 module CLaSH.Netlist.BlackBox where

--- a/clash-lib/src/CLaSH/Netlist/BlackBox/Parser.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox/Parser.hs
@@ -3,7 +3,6 @@ module CLaSH.Netlist.BlackBox.Parser
   (runParse)
 where
 
-import           Data.ListLike.Text.TextLazy              ()
 import           Data.Text.Lazy                           (Text, pack)
 import           Text.ParserCombinators.UU
 import           Text.ParserCombinators.UU.BasicInstances hiding (Parser)

--- a/clash-lib/src/CLaSH/Netlist/BlackBox/Types.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox/Types.hs
@@ -1,8 +1,7 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -- | Types used in BlackBox modules
 module CLaSH.Netlist.BlackBox.Types where
 
-import Data.Text.Lazy       (Text)
+import Data.Text.Lazy (Text)
 
 -- | A BlackBox Template is a List of Elements
 type BlackBoxTemplate = [Element]

--- a/clash-lib/src/CLaSH/Netlist/BlackBox/Util.hs
+++ b/clash-lib/src/CLaSH/Netlist/BlackBox/Util.hs
@@ -181,9 +181,9 @@ lineToType _ _ = error $ $(curLoc) ++ "Unexpected type manipulation"
 -- | Give a context and a tagged hole (of a template), returns part of the
 -- context that matches the tag of the hole.
 renderTag :: Backend backend
-                 => BlackBoxContext
-                 -> Element
-                 -> State backend Text
+          => BlackBoxContext
+          -> Element
+          -> State backend Text
 renderTag _ (C t)           = return t
 renderTag b O               = fmap (displayT . renderOneLine) . expr False . either id fst . fst $ bbResult b
 renderTag b (I n)           = let (s,_,_) = bbInputs b !! n

--- a/clash-lib/src/CLaSH/Netlist/Types.hs
+++ b/clash-lib/src/CLaSH/Netlist/Types.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskell            #-}
@@ -36,8 +34,6 @@ newtype NetlistMonad a =
                }
   deriving (Functor, Monad, Applicative, MonadWriter [(Identifier,HWType)],
             MonadState NetlistState, Fresh, MonadIO)
-
--- deriving instance MonadState (NetlistState backend) (NetlistMonad backend)
 
 -- | State of the NetlistMonad
 data NetlistState

--- a/clash-lib/src/CLaSH/Netlist/Types.hs
+++ b/clash-lib/src/CLaSH/Netlist/Types.hs
@@ -16,7 +16,7 @@ import Data.IntMap.Lazy                     (IntMap, empty)
 import qualified Data.Text                  as S
 import Data.Text.Lazy                       (Text, pack)
 import GHC.Generics                         (Generic)
-import Unbound.LocallyNameless              (Fresh, FreshMT)
+import Unbound.Generics.LocallyNameless              (Fresh, FreshMT)
 
 import CLaSH.Core.Term                      (Term, TmName)
 import CLaSH.Core.Type                      (Type)

--- a/clash-lib/src/CLaSH/Netlist/Util.hs
+++ b/clash-lib/src/CLaSH/Netlist/Util.hs
@@ -16,7 +16,7 @@ import           Data.HashMap.Strict     (HashMap)
 import qualified Data.HashMap.Strict     as HashMap
 import           Data.Maybe              (catMaybes,fromMaybe)
 import           Data.Text.Lazy          (pack)
-import           Unbound.LocallyNameless (Embed, Fresh, bind, embed, makeName,
+import           Unbound.Generics.LocallyNameless (Embed, Fresh, bind, embed, makeName,
                                           name2Integer, name2String, unbind,
                                           unembed, unrec)
 

--- a/clash-lib/src/CLaSH/Netlist/Util.hs
+++ b/clash-lib/src/CLaSH/Netlist/Util.hs
@@ -80,7 +80,7 @@ synchronizedClk :: HashMap TyConName TyCon -- ^ TyCon cache
                 -> Type
                 -> Maybe (Identifier,Int)
 synchronizedClk tcm ty
-  | not . null . typeFreeVars $ ty = Nothing
+  | not . null . Lens.toListOf typeFreeVars $ ty = Nothing
   | Just (tyCon,args) <- splitTyConAppM ty
   = case name2String tyCon of
       "CLaSH.Sized.Vector.Vec"        -> synchronizedClk tcm (args!!1)
@@ -229,7 +229,7 @@ mkUniqueNormalized (args,binds,res) = do
   let res1  = appendToName (varName res) "_o"
   let bndrs = map fst binds
   let exprs = map (unembed . snd) binds
-  let usesOutput = concatMap (filter (== varName res) . termFreeIds) exprs
+  let usesOutput = concatMap (filter (== varName res) . Lens.toListOf termFreeIds) exprs
   let (res2,extraBndr) = case usesOutput of
                             [] -> (res1,[] :: [(Id, Embed Term)])
                             _  -> let res3 = appendToName (varName res) "_o_sig"

--- a/clash-lib/src/CLaSH/Netlist/Util.hs
+++ b/clash-lib/src/CLaSH/Netlist/Util.hs
@@ -2,8 +2,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns    #-}
 
-{-# OPTIONS_GHC -fcontext-stack=21 #-}
-
 -- | Utilities for converting Core Type/Term to Netlist datatypes
 module CLaSH.Netlist.Util where
 

--- a/clash-lib/src/CLaSH/Netlist/Util.hs
+++ b/clash-lib/src/CLaSH/Netlist/Util.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE PatternGuards   #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns    #-}
 

--- a/clash-lib/src/CLaSH/Normalize.hs
+++ b/clash-lib/src/CLaSH/Normalize.hs
@@ -3,39 +3,40 @@
 -- | Turn CoreHW terms into normalized CoreHW Terms
 module CLaSH.Normalize where
 
-import           Control.Concurrent.Supply (Supply)
-import           Control.Lens              ((.=))
-import qualified Control.Lens              as Lens
-import qualified Control.Monad.State       as State
-import           Data.Either               (partitionEithers)
-import           Data.HashMap.Strict       (HashMap)
-import qualified Data.HashMap.Strict       as HashMap
-import           Data.List                 (mapAccumL)
-import qualified Data.Map                  as Map
-import qualified Data.Maybe                as Maybe
-import qualified Data.Set                  as Set
-import qualified Data.Set.Lens             as Lens
-import           Unbound.Generics.LocallyNameless   (unembed)
+import           Control.Concurrent.Supply        (Supply)
+import           Control.Lens                     ((.=))
+import qualified Control.Lens                     as Lens
+import qualified Control.Monad.State              as State
+import           Data.Either                      (partitionEithers)
+import           Data.HashMap.Strict              (HashMap)
+import qualified Data.HashMap.Strict              as HashMap
+import           Data.List                        (mapAccumL)
+import qualified Data.Map                         as Map
+import qualified Data.Maybe                       as Maybe
+import qualified Data.Set                         as Set
+import qualified Data.Set.Lens                    as Lens
+import           Unbound.Generics.LocallyNameless (unembed)
 
-import           CLaSH.Core.FreeVars       (termFreeIds)
-import           CLaSH.Core.Pretty         (showDoc)
-import           CLaSH.Core.Subst          (substTms)
-import           CLaSH.Core.Term           (Term (..), TmName)
-import           CLaSH.Core.Type           (Type)
-import           CLaSH.Core.TyCon          (TyCon, TyConName)
-import           CLaSH.Core.Util           (collectArgs, mkApps, termType)
-import           CLaSH.Core.Var            (Id,varName)
-import           CLaSH.Netlist.Types       (HWType)
-import           CLaSH.Netlist.Util        (splitNormalized)
+import           CLaSH.Core.FreeVars              (termFreeIds)
+import           CLaSH.Core.Pretty                (showDoc)
+import           CLaSH.Core.Subst                 (substTms)
+import           CLaSH.Core.Term                  (Term (..), TmName)
+import           CLaSH.Core.Type                  (Type)
+import           CLaSH.Core.TyCon                 (TyCon, TyConName)
+import           CLaSH.Core.Util                  (collectArgs, mkApps, termType)
+import           CLaSH.Core.Var                   (Id,varName)
+import           CLaSH.Netlist.Types              (HWType)
+import           CLaSH.Netlist.Util               (splitNormalized)
 import           CLaSH.Normalize.Strategy
-import           CLaSH.Normalize.Transformations ( bindConstantVar, caseCon, reduceConst, topLet )
+import           CLaSH.Normalize.Transformations  (bindConstantVar, caseCon,
+                                                   reduceConst, topLet )
 import           CLaSH.Normalize.Types
 import           CLaSH.Normalize.Util
-import           CLaSH.Rewrite.Combinators ((>->),(!->),repeatR,topdownR)
-import           CLaSH.Rewrite.Types       (DebugLevel (..), RewriteState (..),
-                                            bindings, dbgLevel, tcCache)
-import           CLaSH.Rewrite.Util        (liftRS, runRewrite,
-                                            runRewriteSession)
+import           CLaSH.Rewrite.Combinators        ((>->),(!->),repeatR,topdownR)
+import           CLaSH.Rewrite.Types              (DebugLevel (..), RewriteState (..),
+                                                   bindings, dbgLevel, tcCache)
+import           CLaSH.Rewrite.Util               (liftRS, runRewrite,
+                                                   runRewriteSession)
 import           CLaSH.Util
 
 -- | Run a NormalizeSession in a given environment

--- a/clash-lib/src/CLaSH/Normalize.hs
+++ b/clash-lib/src/CLaSH/Normalize.hs
@@ -14,7 +14,7 @@ import           Data.List                 (mapAccumL)
 import qualified Data.Map                  as Map
 import qualified Data.Maybe                as Maybe
 import qualified Data.Set                  as Set
-import           Unbound.LocallyNameless   (unembed)
+import           Unbound.Generics.LocallyNameless   (unembed)
 
 import           CLaSH.Core.FreeVars       (termFreeIds)
 import           CLaSH.Core.Pretty         (showDoc)

--- a/clash-lib/src/CLaSH/Normalize/Transformations.hs
+++ b/clash-lib/src/CLaSH/Normalize/Transformations.hs
@@ -2,8 +2,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns    #-}
 
-{-# OPTIONS_GHC -fcontext-stack=21 #-}
-
 -- | Transformations of the Normalization process
 module CLaSH.Normalize.Transformations
   ( appProp

--- a/clash-lib/src/CLaSH/Normalize/Transformations.hs
+++ b/clash-lib/src/CLaSH/Normalize/Transformations.hs
@@ -41,12 +41,12 @@ import qualified Data.Maybe                  as Maybe
 import           Unbound.Generics.LocallyNameless     (Bind, Embed (..), bind, embed,
                                               rec, unbind, unembed, unrebind,
                                               unrec, name2String)
--- import           Unbound.LocallyNameless.Ops (unsafeUnbind)
+import           Unbound.Generics.LocallyNameless.Unsafe (unsafeUnbind)
 
 import           CLaSH.Core.DataCon          (DataCon, dcName, dcTag,
                                               dcUnivTyVars)
 import           CLaSH.Core.FreeVars         (termFreeIds, termFreeTyVars,
-                                              termFreeVars, typeFreeVars)
+                                              typeFreeVars)
 import           CLaSH.Core.Pretty           (showDoc)
 import           CLaSH.Core.Subst            (substTm, substTms, substTyInTm,
                                               substTysinTm)
@@ -73,7 +73,7 @@ bindNonRep = inlineBinders nonRepTest
   where
     nonRepTest (Id idName tyE, exprE)
       = (&&) <$> (not <$> (representableType <$> Lens.use typeTranslator <*> Lens.use tcCache <*> pure (unembed tyE)))
-             <*> ((notElem idName . snd) <$> localFreeVars (unembed exprE))
+             <*> (notElem idName <$> localFreeVars Lens.toListOf (unembed exprE))
 
     nonRepTest _ = return False
 
@@ -83,7 +83,7 @@ liftNonRep = liftBinders nonRepTest
   where
     nonRepTest (Id idName tyE, exprE)
       = (&&) <$> (not <$> (representableType <$> Lens.use typeTranslator <*> Lens.use tcCache <*> pure (unembed tyE)))
-             <*> ((elem idName . snd) <$> localFreeVars (unembed exprE))
+             <*> (elem idName <$> localFreeVars Lens.toListOf (unembed exprE))
 
     nonRepTest _ = return False
 
@@ -91,7 +91,7 @@ liftNonRep = liftBinders nonRepTest
 typeSpec :: NormRewrite
 typeSpec ctx e@(TyApp e1 ty)
   | (Var _ _,  args) <- collectArgs e1
-  , null $ typeFreeVars ty
+  , null $ Lens.toListOf typeFreeVars ty
   , (_, []) <- Either.partitionEithers args
   = specializeNorm False ctx e
 
@@ -102,7 +102,7 @@ nonRepSpec :: NormRewrite
 nonRepSpec ctx e@(App e1 e2)
   | (Var _ _, args) <- collectArgs e1
   , (_, [])     <- Either.partitionEithers args
-  , null $ termFreeTyVars e2
+  , null $ Lens.toListOf termFreeTyVars e2
   = R $ do tcm <- Lens.use tcCache
            e2Ty <- termType tcm e2
            localVar <- isLocalVar e2
@@ -179,7 +179,7 @@ caseCon _ c@(Case scrut _ alts)
     case dcAltM of
       Just (DataPat _ pxs, e) ->
         let (tvs,xs) = unrebind pxs
-            fvs = termFreeIds e
+            fvs = Lens.toListOf termFreeIds e
             (binds,_) = List.partition ((`elem` fvs) . varName . fst)
                       $ zip xs (Either.lefts args)
             e' = case binds of
@@ -212,7 +212,8 @@ caseCon _ e@(Case _ _ [alt]) = R $ do
     DefaultPat    -> changed altE
     LitPat _      -> changed altE
     DataPat _ pxs -> let (tvs,xs)   = unrebind pxs
-                         (ftvs,fvs) = termFreeVars altE
+                         ftvs       = Lens.toListOf termFreeTyVars altE
+                         fvs        = Lens.toListOf termFreeIds altE
                          usedTvs    = filter ((`elem` ftvs) . varName) tvs
                          usedXs     = filter ((`elem` fvs) . varName) xs
                      in  case (usedTvs,usedXs) of
@@ -281,7 +282,7 @@ topLet _ e = return e
 deadCode :: NormRewrite
 deadCode _ e@(Letrec binds) = R $ do
     (xes, body) <- fmap (first unrec) $ unbind binds
-    let bodyFVs = termFreeIds body
+    let bodyFVs = Lens.toListOf termFreeIds body
         (xesUsed,xesOther) = List.partition
                                ( (`elem` bodyFVs )
                                . varName
@@ -294,7 +295,7 @@ deadCode _ e@(Letrec binds) = R $ do
   where
     findUsedBndrs used []      _     = used
     findUsedBndrs used explore other =
-      let fvsUsed = concatMap (termFreeIds . unembed . snd) explore
+      let fvsUsed = concatMap (Lens.toListOf termFreeIds . unembed . snd) explore
           (explore',other') = List.partition
                                 ( (`elem` fvsUsed)
                                 . varName
@@ -323,7 +324,7 @@ inlineClosed _ e@(collectArgs -> (Var _ f,args))
         bodyMaybe <- fmap (HashMap.lookup f) $ Lens.use bindings
         case bodyMaybe of
           -- Don't inline recursive expressions
-          Just (_,body) -> if f `elem` (termFreeIds body)
+          Just (_,body) -> if f `elem` (Lens.toListOf termFreeIds body)
                               then return e
                               else changed (mkApps body args)
           _ -> return e
@@ -337,7 +338,7 @@ inlineClosed _ e@(Var _ f) = R $ do
       bodyMaybe <- fmap (HashMap.lookup f) $ Lens.use bindings
       case bodyMaybe of
         -- Don't inline recursive expressions
-        Just (_,body) -> if f `elem` (termFreeIds body)
+        Just (_,body) -> if f `elem` (Lens.toListOf termFreeIds body)
                             then return e
                             else changed body
         _ -> return e
@@ -373,7 +374,7 @@ constantSpec :: NormRewrite
 constantSpec ctx e@(App e1 e2)
   | (Var _ _, args) <- collectArgs e1
   , (_, [])     <- Either.partitionEithers args
-  , null $ termFreeTyVars e2
+  , null $ Lens.toListOf termFreeTyVars e2
   , isConstant e2
   = specializeNorm False ctx e
 

--- a/clash-lib/src/CLaSH/Normalize/Transformations.hs
+++ b/clash-lib/src/CLaSH/Normalize/Transformations.hs
@@ -73,7 +73,7 @@ bindNonRep = inlineBinders nonRepTest
   where
     nonRepTest (Id idName tyE, exprE)
       = (&&) <$> (not <$> (representableType <$> Lens.use typeTranslator <*> Lens.use tcCache <*> pure (unembed tyE)))
-             <*> (notElem idName <$> localFreeVars Lens.toListOf (unembed exprE))
+             <*> (notElem idName <$> (Lens.toListOf <$> localFreeIds <*> pure (unembed exprE)))
 
     nonRepTest _ = return False
 
@@ -83,7 +83,7 @@ liftNonRep = liftBinders nonRepTest
   where
     nonRepTest (Id idName tyE, exprE)
       = (&&) <$> (not <$> (representableType <$> Lens.use typeTranslator <*> Lens.use tcCache <*> pure (unembed tyE)))
-             <*> (elem idName <$> localFreeVars Lens.toListOf (unembed exprE))
+             <*> (elem idName <$> (Lens.toListOf <$> localFreeIds <*> pure (unembed exprE)))
 
     nonRepTest _ = return False
 

--- a/clash-lib/src/CLaSH/Normalize/Transformations.hs
+++ b/clash-lib/src/CLaSH/Normalize/Transformations.hs
@@ -38,10 +38,10 @@ import qualified Data.Either                 as Either
 import qualified Data.HashMap.Lazy           as HashMap
 import qualified Data.List                   as List
 import qualified Data.Maybe                  as Maybe
-import           Unbound.LocallyNameless     (Bind, Embed (..), bind, embed,
+import           Unbound.Generics.LocallyNameless     (Bind, Embed (..), bind, embed,
                                               rec, unbind, unembed, unrebind,
                                               unrec, name2String)
-import           Unbound.LocallyNameless.Ops (unsafeUnbind)
+-- import           Unbound.LocallyNameless.Ops (unsafeUnbind)
 
 import           CLaSH.Core.DataCon          (DataCon, dcName, dcTag,
                                               dcUnivTyVars)

--- a/clash-lib/src/CLaSH/Normalize/Transformations.hs
+++ b/clash-lib/src/CLaSH/Normalize/Transformations.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE PatternGuards   #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns    #-}
 

--- a/clash-lib/src/CLaSH/Normalize/Util.hs
+++ b/clash-lib/src/CLaSH/Normalize/Util.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE LambdaCase      #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE ViewPatterns    #-}
 
 -- | Utility functions used by the normalisation transformations
 module CLaSH.Normalize.Util where

--- a/clash-lib/src/CLaSH/Normalize/Util.hs
+++ b/clash-lib/src/CLaSH/Normalize/Util.hs
@@ -15,6 +15,7 @@ import           Data.HashMap.Lazy       (HashMap)
 import qualified Data.HashMap.Lazy       as HashMap
 import qualified Data.Maybe              as Maybe
 import qualified Data.Set                as Set
+import qualified Data.Set.Lens           as Lens
 import           Unbound.Generics.LocallyNameless (Fresh, bind, embed, rec)
 
 import           CLaSH.Core.FreeVars     (termFreeIds)
@@ -73,7 +74,7 @@ callGraph :: [TmName] -- ^ List of functions that should not be inspected
 callGraph visited bindingMap root = node:other
   where
     rootTm = Maybe.fromMaybe (error $ show root ++ " is not a global binder") $ HashMap.lookup root bindingMap
-    used   = Set.toList $ termFreeIds (snd rootTm)
+    used   = Set.toList $ Lens.setOf termFreeIds (snd rootTm)
     node   = (root,used)
     other  = concatMap (callGraph (root:visited) bindingMap) (filter (`notElem` visited) used)
 

--- a/clash-lib/src/CLaSH/Normalize/Util.hs
+++ b/clash-lib/src/CLaSH/Normalize/Util.hs
@@ -15,7 +15,7 @@ import           Data.HashMap.Lazy       (HashMap)
 import qualified Data.HashMap.Lazy       as HashMap
 import qualified Data.Maybe              as Maybe
 import qualified Data.Set                as Set
-import           Unbound.LocallyNameless (Fresh, bind, embed, rec)
+import           Unbound.Generics.LocallyNameless (Fresh, bind, embed, rec)
 
 import           CLaSH.Core.FreeVars     (termFreeIds)
 import           CLaSH.Core.Var          (Var (Id))

--- a/clash-lib/src/CLaSH/Normalize/Util.hs
+++ b/clash-lib/src/CLaSH/Normalize/Util.hs
@@ -1,8 +1,6 @@
-{-# LANGUAGE LambdaCase   #-}
+{-# LANGUAGE LambdaCase      #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE ViewPatterns #-}
-
-{-# OPTIONS_GHC -fcontext-stack=21 #-}
+{-# LANGUAGE ViewPatterns    #-}
 
 -- | Utility functions used by the normalisation transformations
 module CLaSH.Normalize.Util where

--- a/clash-lib/src/CLaSH/Primitives/Types.hs
+++ b/clash-lib/src/CLaSH/Primitives/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 -- | Type and instance definitions for Primitive
 module CLaSH.Primitives.Types where
 

--- a/clash-lib/src/CLaSH/Rewrite/Combinators.hs
+++ b/clash-lib/src/CLaSH/Rewrite/Combinators.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables #-}
+
 -- | Rewriting combinators and traversals
 module CLaSH.Rewrite.Combinators where
 

--- a/clash-lib/src/CLaSH/Rewrite/Combinators.hs
+++ b/clash-lib/src/CLaSH/Rewrite/Combinators.hs
@@ -7,7 +7,7 @@ import qualified Control.Monad.Writer        as Writer
 import qualified Data.Monoid                 as Monoid
 import           Unbound.Generics.LocallyNameless     (Embed, Fresh, bind, embed, rec,
                                               unbind, unembed, unrec)
--- import           Unbound.LocallyNameless.Ops (unsafeUnbind)
+import           Unbound.Generics.LocallyNameless.Unsafe (unsafeUnbind)
 
 import           CLaSH.Core.Term             (Pat, Term (..))
 import           CLaSH.Core.Util             (patIds)

--- a/clash-lib/src/CLaSH/Rewrite/Combinators.hs
+++ b/clash-lib/src/CLaSH/Rewrite/Combinators.hs
@@ -5,9 +5,9 @@ module CLaSH.Rewrite.Combinators where
 import           Control.Monad               ((<=<), (>=>))
 import qualified Control.Monad.Writer        as Writer
 import qualified Data.Monoid                 as Monoid
-import           Unbound.LocallyNameless     (Embed, Fresh, bind, embed, rec,
+import           Unbound.Generics.LocallyNameless     (Embed, Fresh, bind, embed, rec,
                                               unbind, unembed, unrec)
-import           Unbound.LocallyNameless.Ops (unsafeUnbind)
+-- import           Unbound.LocallyNameless.Ops (unsafeUnbind)
 
 import           CLaSH.Core.Term             (Pat, Term (..))
 import           CLaSH.Core.Util             (patIds)

--- a/clash-lib/src/CLaSH/Rewrite/Types.hs
+++ b/clash-lib/src/CLaSH/Rewrite/Types.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskell            #-}
-{-# LANGUAGE TypeSynonymInstances       #-}
 
 -- | Type and instance definitions for Rewrite modules
 module CLaSH.Rewrite.Types where

--- a/clash-lib/src/CLaSH/Rewrite/Types.hs
+++ b/clash-lib/src/CLaSH/Rewrite/Types.hs
@@ -13,7 +13,7 @@ import Control.Monad.State       (MonadState, StateT)
 import Control.Monad.Writer      (MonadWriter, WriterT)
 import Data.HashMap.Strict       (HashMap)
 import Data.Monoid               (Any)
-import Unbound.LocallyNameless   (Fresh, FreshMT)
+import Unbound.Generics.LocallyNameless   (Fresh, FreshMT)
 
 import CLaSH.Core.Term           (Term, TmName)
 import CLaSH.Core.Type           (Type)

--- a/clash-lib/src/CLaSH/Rewrite/Util.hs
+++ b/clash-lib/src/CLaSH/Rewrite/Util.hs
@@ -26,12 +26,12 @@ import qualified Data.HashMap.Strict         as HMS
 import qualified Data.Map                    as Map
 import qualified Data.Monoid                 as Monoid
 import qualified Data.Set                    as Set
-import           Unbound.LocallyNameless     (Collection (..), Fresh, bind,
+import           Unbound.Generics.LocallyNameless     (Collection (..), Fresh, bind,
                                               embed, makeName, name2String,
                                               rebind, rec, string2Name, unbind,
                                               unembed, unrec)
-import qualified Unbound.LocallyNameless     as Unbound
-import           Unbound.Util                (filterC)
+import qualified Unbound.Generics.LocallyNameless     as Unbound
+-- import           Unbound.Util                (filterC)
 
 import           CLaSH.Core.DataCon          (dataConInstArgTys)
 import           CLaSH.Core.FreeVars         (termFreeVars, typeFreeVars)

--- a/clash-lib/src/CLaSH/Rewrite/Util.hs
+++ b/clash-lib/src/CLaSH/Rewrite/Util.hs
@@ -1,13 +1,5 @@
-{-# LANGUAGE DeriveFoldable    #-}
-{-# LANGUAGE DeriveFunctor     #-}
-{-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE Rank2Types        #-}
 {-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE TupleSections     #-}
-{-# LANGUAGE TypeOperators     #-}
-{-# LANGUAGE ViewPatterns      #-}
-
-{-# OPTIONS_GHC -fcontext-stack=21 #-}
 
 -- | Utilities for rewriting: e.g. inlining, specialisation, etc.
 module CLaSH.Rewrite.Util where

--- a/clash-lib/src/CLaSH/Rewrite/Util.hs
+++ b/clash-lib/src/CLaSH/Rewrite/Util.hs
@@ -275,7 +275,7 @@ substituteBinders ((bndr,valE):rest) others res = substituteBinders rest' others
 --               -> RewriteMonad m (c TmName)
 localFreeVars to term = do
   globalBndrs <- Lens.use bindings
-  return (to (termFreeIds . Lens.filtered (`HML.member` globalBndrs)) term)
+  return (to (termFreeIds . Lens.filtered (not . (`HML.member` globalBndrs))) term)
 
   -- let (tyFVs,tmFVs) = termFreeVars term
   -- return ( tyFVs

--- a/clash-lib/src/CLaSH/Util.hs
+++ b/clash-lib/src/CLaSH/Util.hs
@@ -32,8 +32,8 @@ import Data.Version                   (Version)
 import Control.Lens
 import Debug.Trace                    (trace)
 import qualified Language.Haskell.TH  as TH
-import Unbound.LocallyNameless        (Embed(..))
-import Unbound.LocallyNameless.Name   (Name(..))
+import Unbound.Generics.LocallyNameless        (Embed(..))
+import Unbound.Generics.LocallyNameless.Name   (Name(..))
 
 #ifdef CABAL
 import qualified Paths_clash_lib      (version)
@@ -51,8 +51,8 @@ instance Monad m => MonadUnique (StateT Int m) where
     return supply
 
 instance Hashable (Name a) where
-  hashWithSalt salt (Nm _ (str,int)) = hashWithSalt salt (hashWithSalt (hash int) str)
-  hashWithSalt salt (Bn _ i0 i1)     = hashWithSalt salt (hash i0 `hashWithSalt` i1)
+  hashWithSalt salt (Fn str int) = hashWithSalt salt (hashWithSalt (hash int) str)
+  hashWithSalt salt (Bn i0  i1)  = hashWithSalt salt (hash i0 `hashWithSalt` i1)
 
 instance (Ord a) => Ord (Embed a) where
   compare (Embed a) (Embed b) = compare a b

--- a/clash-lib/src/CLaSH/Util.hs
+++ b/clash-lib/src/CLaSH/Util.hs
@@ -2,8 +2,6 @@
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE Rank2Types           #-}
 {-# LANGUAGE TupleSections        #-}
-{-# LANGUAGE TypeOperators        #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 

--- a/install_clash
+++ b/install_clash
@@ -5,6 +5,16 @@ cabal clean
 cabal install
 cd ..
 
+cd clash-systemverilog
+cabal clean
+cabal install
+cd ..
+
+cd clash-vhdl
+cabal clean
+cabal install
+cd ..
+
 cd clash-ghc
 cabal clean
 cabal install


### PR DESCRIPTION
A version of the `unbound` library for working with binders, but based on `GHC.Generics` instead of the `RepLib` library.

Compiling the `i2c` example went from using `4.2gb` and `145s` to compile, to `1.6gb` and `45s` to compile. Also, `GHC.Generics` is more future-proof than `RepLib` template-haskell aspects.